### PR TITLE
Edit the order of arguments in the Config class get-method

### DIFF
--- a/batchflow/config.py
+++ b/batchflow/config.py
@@ -45,7 +45,7 @@ class Config:
             value = self._get(variables, config, pop=True, **kwargs)
         return value
 
-    def get(self, variables, config=None, default=None):
+    def get(self, variables, default=None, config=None):
         """ Returns variables from config
 
         Parameters

--- a/batchflow/models/base.py
+++ b/batchflow/models/base.py
@@ -48,7 +48,7 @@ class BaseModel:
         return Config().pop(variables, config, **kwargs)
 
     @classmethod
-    def get(cls, variables, config, default=None):
+    def get(cls, variables, default=None, config=None):
         """ Return variables from config """
         return Config().get(variables, default=default, config=config)
 

--- a/batchflow/models/base.py
+++ b/batchflow/models/base.py
@@ -50,7 +50,7 @@ class BaseModel:
     @classmethod
     def get(cls, variables, config, default=None):
         """ Return variables from config """
-        return Config().get(variables, config, default=default)
+        return Config().get(variables, default=default, config=config)
 
     @classmethod
     def put(cls, variable, value, config):


### PR DESCRIPTION
I have found 96 usages of method get in the batchflow repository. Some of them were modified after method get signature changing, but it was not necessary, and moreover, it was a mistake. So I rolled that changes back. And finally, I've found no usages of method get(...) which were depended on the order of unnamed arguments. 