### PR TITLE
Encoder decoder

### DIFF
--- a/batchflow/models/tf/__init__.py
+++ b/batchflow/models/tf/__init__.py
@@ -19,7 +19,7 @@ from .resattention import ResNetAttention, ResNetAttention56, ResNetAttention92
 from .densenet_fc import DenseNetFC, DenseNetFC56, DenseNetFC67, DenseNetFC103
 from .refinenet import RefineNet
 from .gcn import GlobalConvolutionNetwork as GCN
-from .encoder_decoder import EncoderDecoder
+from .encoder_decoder import EncoderDecoder, AutoEncoder, VariationalAutoEncoder
 from .pyramidnet import PyramidNet, PyramidNet18, PyramidNet34, PyramidNet50, PyramidNet101, PyramidNet152
 from .tf_sampler import TfSampler
 from .deep_galerkin import DeepGalerkin

--- a/batchflow/models/tf/encoder_decoder.py
+++ b/batchflow/models/tf/encoder_decoder.py
@@ -161,9 +161,10 @@ class EncoderDecoder(TFModel):
 
 
     @classmethod
-    def block(cls, inputs, name='default_block', **kwargs):
-        """ Default block for processing tensors. Does not change shape of tensor.
-        Does 3x3 convolution followed by batch-norm and activation.
+    def block(cls, inputs, name='block', **kwargs):
+        """ Default conv block for processing tensors in encoder and decoder.
+        By default makes 3x3 convolutions followed by batch-norm and activation.
+        Does not change tensor shapes.
         """
         layout = kwargs.pop('layout', None) or 'cna'
         filters = kwargs.pop('filters', None) or cls.num_channels(inputs)

--- a/batchflow/models/tf/encoder_decoder.py
+++ b/batchflow/models/tf/encoder_decoder.py
@@ -8,34 +8,41 @@ from .resnet import ResNet18
 
 
 class EncoderDecoder(TFModel):
-    """ Encoder-decoder architecture
+    """ Encoder-decoder architecture. Allows to combine features of different models,
+    e.g. ResNet and DenseNet, in order to create new ones with just a few lines of code.
 
-    **Configuration**
-
+    Parameters
+    ----------
     inputs : dict
-        dict with 'images' (see :meth:`~.TFModel._make_inputs`)
+        Dictionary with 'images' (see :meth:`~.TFModel._make_inputs`)
 
     body : dict
         encoder : dict
             base_class : TFModel
-                a model implementing ``make_encoder`` method which returns tensors
-                with encoded representation of the inputs
+                Model implementing ``make_encoder`` method which returns tensors
+                with encoded representation of the inputs. Defaults to ResNet18.
             other args
-                parameters for base class ``make_encoder`` method
+                Parameters for base class ``make_encoder`` method.
 
         embedding : dict
-            :func:`~.layers.conv_block` parameters for the bottom block
+            :func:`~.layers.conv_block` parameters for the bottom block.
 
         decoder : dict
             num_stages : int
-                number of upsampling blocks
+                Number of upsampling blocks.
             factor : int or list of int
-                if int, the total upsampling factor for all blocks combined.
-                if list, upsampling factors for each block.
+                If int, the total upsampling factor for all blocks combined.
+                If list, upsampling factors for each stage.
+            bridges : bool
+                Whether to concatenate upsampled tensor with stored pre-downsample encoding.
+            use_post : bool
+                Whether to post-process tensors after upsampling.
             layout : str
-                upsampling method (see :func:`~.layers.upsample`)
-
-            other :func:`~.layers.upsample` parameters.
+                Upsampling method (see :func:`~.layers.upsample`).
+            block : dict
+                Parameters for post-processing blocks.
+            other args
+                Parameters for :func:`~.layers.upsample`.
 
     Examples
     --------
@@ -43,134 +50,176 @@ class EncoderDecoder(TFModel):
     create an embedding that contains 16 channels,
     and build a decoder with 3 upsampling stages to scale the embedding 8 times with transposed convolutions::
 
-        config = {
+    >>> config = {
             'inputs': dict(images={'shape': B('image_shape'), 'name': 'targets'}),
             'initial_block/inputs': 'images',
             'encoder/base_class': ResNet18,
             'embedding/filters': 16,
             'decoder': dict(num_stages=3, factor=8, layout='tna')
         }
+
+
+    Preprocess input image with 7x7 convolutions, use DenseNet as encoder to downsample the image
+    with a factor of 16 with every DenseBlock concatenating its input to the output, don't change
+    shape of resulted tensor in embedding, decode compressed image to initial shape by alternating
+    ResNeXt and DenseNet blocks with desired parameters:
+
+    >>> config = {
+            'inputs': dict(images={'shape': B('image_shape')},
+                           masks={'name': 'targets', 'shape': B('image_shape')}),
+            'initial_block': {'inputs': 'images',
+                              'layout': 'cna', 'filters': 4, 'kernel_size': 7},
+            'body/encoder': {'base_class': DenseNet,
+                             'num_layers': [2, 2, 3, 3, 4],
+                             'block/growth_rate': 6, 'block/skip': True},
+            'body/decoder': {'num_stages': 4, 'factor': 16,
+                             'bridges': True,
+                             'block': {'base_block':[ResNet.block, DenseNet.block, ResNet.block, DenseNet.block],
+                                       'layout': ['cnacna', 'nacd', 'cnacna', 'nacd']
+                                       'filters': [256, None, 64, None], 'resnext': True,
+                                       'num_layers': [None, 4, None, 2], 'growth_rate': 6, 'skip': False}},
+        }
+
+    Notes
+    -----
+    Downsampling is done one less time than the length of `filters` (or other size-defining parameter) list in the
+    `encoder` configuration. That is due to the fact that the first block is used as preprocessing of input tensors.
     """
     @classmethod
     def default_config(cls):
         config = TFModel.default_config()
         config['body']['encoder'] = dict(base_class=ResNet18)
-        config['body']['decoder'] = dict(layout='tna', factor=8, num_stages=3)
-        config['body']['embedding'] = dict(layout='cna', filters=8)
-        config['loss'] = 'mse'
+        config['body']['embedding'] = dict(layout='cna', kernel_size=1)
+        config['body']['decoder'] = dict(layout='tna', factor=8, num_stages=3, bridges=False, use_post=False)
+        config['body']['decoder']['block'] = dict(base_block=conv_block, layout='cna', activation=tf.nn.relu)
+        config['head'] = dict(layout='c', kernel_size=1)
         return config
+
 
     def build_config(self, names=None):
         config = super().build_config(names)
         config['head']['targets'] = self.targets
         return config
 
+
     @classmethod
     def body(cls, inputs, name='body', **kwargs):
-        """ Create encoder, embedding and decoder
-
-        Parameters
-        ----------
-        inputs : tf.Tensor
-            input tensor
-        filters : tuple of int
-            number of filters in decoder blocks
-        name : str
-            scope name
-
-        Returns
-        -------
-        tf.Tensor
-        """
+        """ Create encoder, embedding and decoder. """
         kwargs = cls.fill_params('body', **kwargs)
         encoder = kwargs.pop('encoder')
         decoder = kwargs.pop('decoder')
         embedding = kwargs.pop('embedding')
 
         with tf.variable_scope(name):
+            # Encoder: transition down
             encoder_outputs = cls.encoder(inputs, **encoder, **kwargs)
 
+            # Bottleneck: working with compressed representation
             x = cls.embedding(encoder_outputs[-1], **embedding, **kwargs)
-            if x != encoder_outputs[-1]:
-                encoder_outputs += [x]
+            encoder_outputs.append(x)
 
+            #Decoder: transition up
             x = cls.decoder(encoder_outputs, **decoder, **kwargs)
         return x
 
+
     @classmethod
     def head(cls, inputs, targets, name='head', **kwargs):
-        """ Linear convolutions with kernel 1 """
+        """ Linear convolutions with kernel size of 1. """
+        kwargs = cls.fill_params('head', **kwargs)
         with tf.variable_scope(name):
             x = cls.crop(inputs, targets, kwargs['data_format'])
             channels = cls.num_channels(targets)
-            x = conv_block(x, layout='c', filters=channels, kernel_size=1, **kwargs)
+            x = conv_block(x, filters=channels, **kwargs)
         return x
 
+
     @classmethod
-    def encoder(cls, inputs, base_class, name='encoder', **kwargs):
-        """ Create encoder from a base_class model
+    def encoder(cls, inputs, name='encoder', **kwargs):
+        """ Create encoder from a `base_class` model
 
         Parameters
         ----------
         inputs : tf.Tensor
-            input tensor
+            Input tensor.
+
         base_class : TFModel
-            a model class (default=ResNet101).
-            Should implement ``make_encoder`` method.
+            Model class (default is ResNet18). Should implement ``make_encoder`` method.
+
         name : str
-            scope name
+            Scope name.
+
         kwargs : dict
-            parameters for ``make_encoder`` method
+            Parameters for ``make_encoder`` method.
 
         Returns
         -------
-        list of tf.Tensor
+        list of tf.Tensors
         """
+        base_class = kwargs.pop('base_class')
         x = base_class.make_encoder(inputs, name=name, **kwargs)
         return x
 
+
     @classmethod
     def embedding(cls, inputs, name='embedding', **kwargs):
-        """ Create embedding from inputs tensor
+        """ Create embedding from inputs tensor.
 
         Parameters
         ----------
         inputs : tf.Tensor
-            input tensor
+            Input tensor.
+
         name : str
-            scope name
+            Scope name.
+
         kwargs : dict
-            parameters for :func:`~.tf.layers.conv_block`
+            Parameters for :func:`~.tf.layers.conv_block`.
 
         Returns
         -------
         tf.Tensor
         """
+        kwargs['filters'] = kwargs.get('filters') or cls.num_channels(inputs)
         if kwargs.get('layout') is not None:
             x = conv_block(inputs, name=name, **kwargs)
         else:
             x = inputs
         return x
 
+
     @classmethod
     def decoder(cls, inputs, name='decoder', **kwargs):
-        """ Create decoder with a given number of upsampling stages
+        """ Create decoder with a given number of upsampling stages.
 
         Parameters
         ----------
         inputs : tf.Tensor
-            input tensor
+            Input tensor.
+
         name : str
-            scope name
+            Scope name.
+
+        bridges : bool
+            Whether to concatenate upsampled tensor with stored pre-downsample encoding.
+
+        use_post : bool
+            Whether to post-process tensors after upsampling.
+
+        block : dict
+            Parameters for post-processing blocks.
+
         kwargs : dict
-            parameters for ``upsample`` method
+            Parameters for ``upsample`` method.
 
         Returns
         -------
         tf.Tensor
         """
-        steps = kwargs.pop('num_stages', len(inputs)-1)
-        factor = kwargs.pop('factor')
+        steps = kwargs.pop('num_stages', len(inputs)-2)
+        factor, bridges, use_post = cls.pop(['factor', 'bridges', 'use_post'], kwargs)
+
+        block_args = kwargs.pop('block') if use_post else None
 
         if isinstance(factor, int):
             factor = int(factor ** (1/steps))
@@ -180,6 +229,24 @@ class EncoderDecoder(TFModel):
 
         with tf.variable_scope(name):
             x = inputs[-1]
+
+            axis = cls.channels_axis(kwargs.get('data_format'))
             for i in range(steps):
-                x = cls.upsample(x, factor=factor[i], name='decoder-'+str(i), **kwargs)
+                with tf.variable_scope('decoder-'+str(i)):
+                    # Upsample by a desired factor
+                    x = cls.upsample(x, factor=factor[i], name='upsample', **kwargs)
+
+                    # Post-process resulting tensor
+                    if block_args is not None:
+                        args = {key: value[i] for key, value in block_args.items()
+                                if isinstance(value, list)}
+                        args = {**kwargs, **block_args, **args} # enforce priority of subkeys
+                        args = {key: value for key, value in args.items() if value is not None}
+                        base_block = args.get('base_block')
+                        x = base_block(x, name='post', **args)
+
+                    # Concatenate it with stored encoding of the ~same shape
+                    if bridges and (i < len(inputs)-3):
+                        x = cls.crop(x, inputs[-i-3], data_format=kwargs.get('data_format'))
+                        x = tf.concat((x, inputs[-i-3]), axis=axis, name='bridges-concat')
         return x

--- a/batchflow/models/tf/encoder_decoder.py
+++ b/batchflow/models/tf/encoder_decoder.py
@@ -113,11 +113,11 @@ class EncoderDecoder(TFModel):
         config = TFModel.default_config()
         config['body/encoder'] = dict(base=None, num_stages=None)
         config['body/encoder/downsample'] = dict(layout='p', pool_size=2, pool_strides=2)
-        config['body/encoder/blocks'] = dict(base=cls.default_block)
-        config['body/embedding'] = dict(base=cls.default_block)
+        config['body/encoder/blocks'] = dict(base=cls.block)
+        config['body/embedding'] = dict(base=cls.block)
         config['body/decoder'] = dict(skip=True, num_stages=None, factor=None)
         config['body/decoder/upsample'] = dict(layout='tna')
-        config['body/decoder/blocks'] = dict(base=cls.default_block)
+        config['body/decoder/blocks'] = dict(base=cls.block)
         config['head'] = dict(layout='c', kernel_size=1)
         return config
 
@@ -161,7 +161,7 @@ class EncoderDecoder(TFModel):
 
 
     @classmethod
-    def default_block(cls, inputs, name='default_block', **kwargs):
+    def block(cls, inputs, name='default_block', **kwargs):
         """ Default block for processing tensors. Does not change shape of tensor.
         Does 3x3 convolution followed by batch-norm and activation.
         """

--- a/batchflow/models/tf/resnet.py
+++ b/batchflow/models/tf/resnet.py
@@ -425,6 +425,13 @@ class ResNet(TFModel):
         """
         num_blocks = cls.get('num_blocks', config=cls.fill_params('body', **kwargs))
 
+        if kwargs.get('filters') is None:
+            raise ValueError('Specify number of filters')
+
+        if len(num_blocks) != len(kwargs.get('filters')):
+            msg = '{} encoder requires {} filters instead of {}'
+            raise ValueError(msg.format(cls.__name__, len(num_blocks), len(kwargs.get('filters'))))
+
         with tf.variable_scope(name):
             x = cls.body(inputs, name='body', **kwargs)
 

--- a/batchflow/models/tf/resnet.py
+++ b/batchflow/models/tf/resnet.py
@@ -422,6 +422,11 @@ class ResNet(TFModel):
         Returns
         -------
         tf.Tensor
+
+        Raises
+        ------
+        ValueError
+            If `filters` is not specified or number of `num_blocks` not equal to number of `filters` provided.
         """
         num_blocks = cls.get('num_blocks', config=cls.fill_params('body', **kwargs))
 

--- a/batchflow/tests/encoder_decoder_test.py
+++ b/batchflow/tests/encoder_decoder_test.py
@@ -11,8 +11,8 @@ from batchflow.models.tf import EncoderDecoder, ResNet, MobileNet, DenseNet
 
 
 ENCODERS = [
-    {'base_class': ResNet, 'num_blocks': [2]*3, 'filters': [13]*3},
-    {'base_class': DenseNet, 'num_layers': [2]*3, 'growth_rate': 13},
+    {'base': ResNet, 'num_blocks': [2]*3, 'filters': [13]*3},
+    {'base': DenseNet, 'num_layers': [2]*3, 'growth_rate': 13},
     {'num_stages': 2, 'downsample': {'layout': 'v'}, 'blocks': {'layout':'cna', 'filters':[32]*2}},
     {'num_stages': 2, 'blocks': {'base': ResNet.block, 'filters':[13]*2}},
 ]
@@ -25,7 +25,7 @@ EMBEDDINGS = [
 
 
 DECODERS = [
-    {'num_stages': 2, 'factor': 9, 'bridges': False, 'upsample': {'layout': 'X'}},
+    {'num_stages': 2, 'factor': 9, 'skip': False, 'upsample': {'layout': 'X'}},
     {'num_stages': 4, 'blocks': {'layout': 'cna', 'filters': [23]*4}},
     {'num_stages': 4, 'blocks': {'base': DenseNet.block, 'num_layers': [2]*4, 'growth_rate': 23}},
 ]

--- a/batchflow/tests/encoder_decoder_test.py
+++ b/batchflow/tests/encoder_decoder_test.py
@@ -1,0 +1,57 @@
+""" Test for EncoderDecoder model architecture.
+First of all, we define possible types of encoders, embeddings and decoders.
+Later every combination of encoder, embedding, decoder is combined into one model and we initialize it.
+"""
+# pylint: disable=import-error, no-name-in-module
+# pylint: disable=redefined-outer-name
+import pytest
+
+from batchflow.models.tf import EncoderDecoder, ResNet, MobileNet, DenseNet
+
+
+
+ENCODERS = [
+    {'base_class': ResNet, 'num_blocks': [2]*3, 'filters': [13]*3},
+    {'base_class': DenseNet, 'num_layers': [2]*3, 'growth_rate': 13},
+    {'num_stages': 2, 'downsample': {'layout': 'v'}, 'blocks': {'layout':'cna', 'filters':[32]*2}},
+    {'num_stages': 2, 'blocks': {'base': ResNet.block, 'filters':[13]*2}},
+]
+
+
+EMBEDDINGS = [
+    {'layout': 'cna', 'filters': 17},
+    {'base': MobileNet.block, 'width_factor': 2},
+]
+
+
+DECODERS = [
+    {'num_stages': 2, 'factor': 9, 'bridges': False, 'upsample': {'layout': 'X'}},
+    {'num_stages': 4, 'blocks': {'layout': 'cna', 'filters': [23]*4}},
+    {'num_stages': 4, 'blocks': {'base': DenseNet.block, 'num_layers': [2]*4, 'growth_rate': 23}},
+]
+
+
+@pytest.fixture()
+def base_config():
+    """ Fixture to hold default configuration. """
+    config = {
+        'inputs': {'images': {'shape': (16, 16, 1)},
+                   'masks': {'name': 'targets', 'shape': (16, 16, 1)}},
+        'initial_block': {'inputs': 'images'},
+        'loss': 'mse'
+    }
+    return config
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize('encoder', ENCODERS)
+@pytest.mark.parametrize('embedding', EMBEDDINGS)
+@pytest.mark.parametrize('decoder', DECODERS)
+def test_first(base_config, encoder, embedding, decoder):
+    """ Create encoder-decoder architecture from every possible combination
+    of encoder, embedding, decoder, listed in global variables defined above.
+    """
+    base_config.update({'body/encoder': encoder,
+                        'body/embedding': embedding,
+                        'body/decoder': decoder})
+    _ = EncoderDecoder(base_config)


### PR DESCRIPTION
Modified `EncoderDecoder` model in order to:

- add ability to create encoder from individual blocks (e.g. `DenseNet.block`)

- same for embedding and decoder: now we can create them from individual blocks

- add parameter to control skip connections between corresponding encodings/decodings (`UNet`-like)

Also, arguments for upsampling layers are moved to separate key in order to prevent collisions; same for downsampling layers (when encoder is created from blocks). 

Changed order of layers in body of `DenseNet`: from `block-transition-block-transition-block-block` to `block-block-transition-block-transition-block` in order to stay consistent with `ResNet`. Added `make_encoder` method.

In `make_encoder` method of `ResNet` added error handling: otherwise error-messages are very confusing. 

Added tests for encoder-decoder model.

Examples of model configurations can be found either in docstring of class, or in the file with tests.