### PR TITLE
TFModel: microbatching

### DIFF
--- a/batchflow/models/tf/base.py
+++ b/batchflow/models/tf/base.py
@@ -934,8 +934,9 @@ class TFModel(BaseModel):
             if fetches is None:
                 _fetches = tuple()
             else:
-                fetches = [fetches] if isinstance(fetches, str) else fetches
-                _fetches = self._fill_fetches(fetches, default=None)
+                names = [fetches] if isinstance(fetches, str) else fetches
+                _fetches = self._fill_fetches(names, default=None)
+
 
             if not isinstance(train_mode, (tuple, list)):
                 train_mode = [train_mode]
@@ -974,9 +975,10 @@ class TFModel(BaseModel):
                                 outputs += [_output]
                             self.session.run(apply_op, feed_dict=_feed_dicts[-1])
 
-                        outputs = [[item[i] for item in outputs] for i, _ in enumerate(fetches)]
+                        outputs = [[item[i] for item in outputs] for i, _ in enumerate(names)]
                         output = [np.mean(outputs[i]) if 'loss' in name else outputs[i][-1]
-                                  for i, name in enumerate(fetches)]
+                                  for i, name in enumerate(names)]
+                        output = output[0] if isinstance(fetches, str) else output
             else:
                 output = None
 

--- a/batchflow/models/tf/base.py
+++ b/batchflow/models/tf/base.py
@@ -974,8 +974,8 @@ class TFModel(BaseModel):
                                 outputs += [_output]
                             self.session.run(apply_op, feed_dict=_feed_dicts[-1])
 
-                        outputs = np.matrix(outputs)
-                        output = [np.mean([outputs[:, i]]) if 'loss' in name else outputs[-1, i]
+                        outputs = [[item[i] for item in outputs] for i, _ in enumerate(fetches)]
+                        output = [np.mean(outputs[i]) if 'loss' in name else outputs[i][-1]
                                   for i, name in enumerate(fetches)]
             else:
                 output = None

--- a/batchflow/models/tf/base.py
+++ b/batchflow/models/tf/base.py
@@ -240,6 +240,7 @@ class TFModel(BaseModel):
         self.is_training = None
         self.global_step = None
         self.loss = None
+        self.microbatch = None
         self.train_steps = None
         self.optimizers = {}
         self._train_lock = threading.Lock()
@@ -282,6 +283,8 @@ class TFModel(BaseModel):
 
                 config = self.build_config()
                 self._build(config)
+
+                self.microbatch = config.get('microbatch')
 
                 if self.train_steps is None:
                     train_steps = self._make_train_steps(config)

--- a/batchflow/models/tf/base.py
+++ b/batchflow/models/tf/base.py
@@ -894,9 +894,9 @@ class TFModel(BaseModel):
                 microbatch = microbatch or self.microbatch
             self.microbatch = microbatch
 
-            if (microbatch is not False) and (len(list(self.train_steps.values())[0]) == 1):
+            if (microbatch) and (len(list(self.train_steps.values())[0]) == 1):
                 self._make_train_steps(self._full_config, init=False)
-            print('MIIIII', microbatch)
+
             if microbatch is True: # if config option is set to True, but train option left unspectified,
                 microbatch = False # it is faster to pretend that there is no microbatching
 
@@ -905,7 +905,7 @@ class TFModel(BaseModel):
             # updating every of them with `_fill_feed_dict` so tensorflow can work with it
             feed_dict = feed_dict or {}
             feed_dict = {**feed_dict, **kwargs}
-            print('MI', microbatch)
+
             if not microbatch:
                 _feed_dicts = [feed_dict]
             else:
@@ -926,6 +926,7 @@ class TFModel(BaseModel):
             if fetches is None:
                 _fetches = tuple()
             else:
+                fetches = [fetches] if isinstance(fetches, str) else fetches
                 _fetches = self._fill_fetches(fetches, default=None)
 
             if not isinstance(train_mode, (tuple, list)):

--- a/batchflow/models/tf/base.py
+++ b/batchflow/models/tf/base.py
@@ -161,6 +161,11 @@ class TFModel(BaseModel):
                              'body': {'loss': 'dice', 'optimizer': 'RMSProp', 'scope': 'body'}}
                              'custom': {'use': 'body', 'loss': 'ce', 'scope': 'head'}}``
 
+    microbatch : int
+        size of chunks to split every batch in. Allows to process given data sequentially, accumulating gradients
+        from microbatches and applying them once in the end. Can be changed later in the `train` method.
+        Note that the microbatch size must be a divisor of the batch size.
+
     common : dict
         default parameters for all :func:`.conv_block`
 
@@ -863,6 +868,9 @@ class TFModel(BaseModel):
             if True, the whole train step is locked, thus allowing for multithreading.
         train_mode : str or sequence of str
             name(s) of train step to optimize. Regular expressions are allowed.
+        microbatch : int
+            size of chunks to split every batch in. Note that if this option was not specified
+            in the model configuration, the first invocation of this method would create additional operations.
 
         Returns
         -------


### PR DESCRIPTION
Almost always we want to use `batch_size` big enough, so computed gradients are good estimates of true gradients. Unfortunately, that is often can not be done due to memory limitations of our hardware. 

Microbatching allows to sequentially compute (and accumulate) gradients from smaller pieces of data (namely, `microbatches`), and after enough iterations apply them at once.

There are three ways to use this feature:

- `microbatch` option in the `model_config`. Provided an integer value, it would make so that every `Batch` is split into even parts of that length. Example:
```
model_config = {'microbatch': 16}
train_pipeline = ...
train_batch = train_pipeline.next_batch(64, ...)
```

- `microbatch` option in the `model_config`. It can be either integer, True or pretty much anything else that evaluates to True After that, you can pass `microbatch` argument to `train` method in order to set/change microbatch size on the fly. Example:
```
model_config = {'microbatch': 16}
train_pipeline = ...train_model(..., microbatch=32)
train_batch = train_pipeline.next_batch(64, ...)
```

- no config option whatsoever; `microbatch` option in the `train` method. That results in creating additional operations at the first run of the function, but still allows to change the microbatch size later. Example:
```
train_pipeline =  ...train_model(..., microbatch=32)
train_batch = train_pipeline.next_batch(64, ...)
```

Note that the size of microbatch must always be a divisor of batch size.