### PR TITLE
Fix case of torch model single input

### DIFF
--- a/batchflow/models/torch/base.py
+++ b/batchflow/models/torch/base.py
@@ -799,6 +799,9 @@ class TorchModel(BaseModel):
     def predict(self, *args, fetches=None):    # pylint: disable=arguments-differ
         """ Get predictions on the data provided
         """
+        if len(args) == 1:
+            args = args + (None, )
+        
         *inputs, targets = self._fill_input(*args)
         self.model.eval()
 


### PR DESCRIPTION
If len(args) == 1, then, for example:

*inputs, targets = tuple([1])
print(inputs, targets)
<< [], 1

I believe this piece of code is not supposed to perform that way.