### PR TITLE
DeepLab v3+

### DIFF
--- a/batchflow/models/tf/__init__.py
+++ b/batchflow/models/tf/__init__.py
@@ -24,4 +24,4 @@ from .pyramidnet import PyramidNet, PyramidNet18, PyramidNet34, PyramidNet50, Py
 from .tf_sampler import TfSampler
 from .deep_galerkin import DeepGalerkin
 from .xception import Xception, XceptionS
-from .deeplab import DeepLab, DeepLabS, DeepLab8, DeepLab16
+from .deeplab import DeepLab, DeepLabXS, DeepLabX8, DeepLabX16

--- a/batchflow/models/tf/__init__.py
+++ b/batchflow/models/tf/__init__.py
@@ -23,3 +23,4 @@ from .encoder_decoder import EncoderDecoder, AutoEncoder, VariationalAutoEncoder
 from .pyramidnet import PyramidNet, PyramidNet18, PyramidNet34, PyramidNet50, PyramidNet101, PyramidNet152
 from .tf_sampler import TfSampler
 from .deep_galerkin import DeepGalerkin
+from .xception import Xception

--- a/batchflow/models/tf/__init__.py
+++ b/batchflow/models/tf/__init__.py
@@ -23,5 +23,5 @@ from .encoder_decoder import EncoderDecoder, AutoEncoder, VariationalAutoEncoder
 from .pyramidnet import PyramidNet, PyramidNet18, PyramidNet34, PyramidNet50, PyramidNet101, PyramidNet152
 from .tf_sampler import TfSampler
 from .deep_galerkin import DeepGalerkin
-from .xception import Xception
+from .xception import Xception, XceptionS
 from .deeplab import DeepLab, DeepLabS, DeepLab8, DeepLab16

--- a/batchflow/models/tf/__init__.py
+++ b/batchflow/models/tf/__init__.py
@@ -24,3 +24,4 @@ from .pyramidnet import PyramidNet, PyramidNet18, PyramidNet34, PyramidNet50, Py
 from .tf_sampler import TfSampler
 from .deep_galerkin import DeepGalerkin
 from .xception import Xception
+from .deeplab import DeepLab, DeepLabS, DeepLab8, DeepLab16

--- a/batchflow/models/tf/base.py
+++ b/batchflow/models/tf/base.py
@@ -1377,6 +1377,40 @@ class TFModel(BaseModel):
         return x
 
     @classmethod
+    def combine(cls, inputs, name='combine', op='conv', data_format='channels_last', **kwargs):
+        """ Combine inputs into one tensor via various transformations.
+
+        Parameters
+        ----------
+        inputs : sequence of tf.Tensor
+            tensors to combine
+        op : str {'concat', 'sum', 'conv'}
+            if 'concat', inputs are concated along channels axis
+            if 'sum', inputs are summed
+            if 'softsum', every tensor is passed through 1x1 convolution in order to have
+            the same number of channels as the first tensor, and then summed
+        data_format : str {'channels_last', 'channels_first'}
+            data format
+        kwargs : dict
+            arguments for :func:`.conv_block`
+        """
+        with tf.variable_scope(name):
+            if op == 'concat':
+                axis = cls.channels_axis(data_format)
+                return tf.concat(inputs, axis=axis, name='combine-concat')
+            if op == 'sum':
+                return tf.add_n(inputs, name='combine-sum')
+            if op == 'softsum':
+                filters = cls.num_channels(inputs[0], data_format=data_format)
+
+                for i in range(1, len(inputs)):
+                    inputs[i] = conv_block(inputs[i], layout='c', filters=filters,
+                                           kernel_size=1, name='conv', **kwargs)
+                return tf.add_n(inputs, name='combine-softsum')
+
+        raise ValueError('`op` must be one of `concat`, `sum`, `softsum`, got {}.'.format(combine_type))
+
+    @classmethod
     def initial_block(cls, inputs, name='initial_block', **kwargs):
         """ Transform inputs with a convolution block
 

--- a/batchflow/models/tf/deeplab.py
+++ b/batchflow/models/tf/deeplab.py
@@ -80,10 +80,10 @@ class DeepLabX(DeepLab):
     def default_config(cls):
         config = super().default_config()
         config['body/encoder/base'] = Xception
-        config['body/encoder/entry'] = dict(num_stages=None, filters=None, strides=2, combine_type='conv')
-        config['body/encoder/middle'] = dict(num_stages=None, filters=None, strides=1, combine_type='sum')
+        config['body/encoder/entry'] = dict(num_stages=None, filters=None, strides=2, combine_op='softsum')
+        config['body/encoder/middle'] = dict(num_stages=None, filters=None, strides=1, combine_op='sum')
         config['body/encoder/exit'] = dict(num_stages=None, filters=None, strides=1,
-                                           depth_activation=True, combine_type='conv')
+                                           depth_activation=True, combine_op='softsum')
         config['body/encoder/downsample'] = dict(layout=None)
         return config
 

--- a/batchflow/models/tf/deeplab.py
+++ b/batchflow/models/tf/deeplab.py
@@ -43,7 +43,6 @@ class DeepLab(EncoderDecoder):
         config['body/entry/downsample'] = dict(layout=None)
         config['body/entry/blocks'] = dict(base=Xception.block, filters=None, strides=2, combine_type='conv')
 
-
         config['body/middle'] = dict(base=Xception.block, num_stages=None,
                                      filters=None, strides=1, combine_type='sum')
 
@@ -115,7 +114,7 @@ class DeepLab8(DeepLab):
     @classmethod
     def default_config(cls):
         config = super().default_config()
-        config['initial_block']: dict(layout='cnacna', filters=[32], kernel_size=3, strides=1)
+        config['initial_block'] = dict(layout='cnacna', filters=32, kernel_size=3, strides=1)
 
         config['body/entry/num_stages'] = 4
         config['body/entry/blocks/filters'] = [[64]*3,
@@ -144,7 +143,7 @@ class DeepLab16(DeepLab):
     @classmethod
     def default_config(cls):
         config = super().default_config()
-        config['initial_block']: dict(layout='cnacna', filters=[32], kernel_size=3, strides=1)
+        config['initial_block'] = dict(layout='cnacna', filters=32, kernel_size=3, strides=1)
 
         config['body/entry/num_stages'] = 4
         config['body/entry/blocks/filters'] = [[64]*3,
@@ -173,7 +172,7 @@ class DeepLabS(DeepLab):
     @classmethod
     def default_config(cls):
         config = super().default_config()
-        config['initial_block']: dict(layout='cna', filters=[32], kernel_size=3, strides=1)
+        config['initial_block'] = dict(layout='cna', filters=32, kernel_size=3, strides=1)
 
         config['body/entry/num_stages'] = 4
         config['body/entry/blocks/filters'] = [[6]*3,

--- a/batchflow/models/tf/deeplab.py
+++ b/batchflow/models/tf/deeplab.py
@@ -11,9 +11,8 @@ from .layers import aspp
 
 class DeepLab(EncoderDecoder):
     """ DeepLab v3+ model archtecture.
-    By default, input is encoded with Xception backbone (entry, backbone_middle and backbone_exit flows),
-    then worked via Atrous Spatial Pyramid Pooling layer, and, finally, restored to original
-    spatial size with simple yet effective decoder module.
+    By default, input is compressed with encoder, then worked via Atrous Spatial Pyramid Pooling layer,
+    and, finally, restored to original spatial size with simple yet effective decoder module.
 
     Parameters
     ----------
@@ -21,34 +20,23 @@ class DeepLab(EncoderDecoder):
         Dictionary with 'images' (see :meth:`~.TFModel._make_inputs`)
 
     body : dict
-        entry : dict
+        encoder : dict
         Dictionary with parameters for entry encoding: downsampling of the inputs.
         See :meth:`~.EncoderDecoder.encoder` arguments.
 
-        backbone_middle : dict
-        Dictionary with parameters for backbone_middle encoding: thorough processing.
-        See :meth:`~.EncoderDecoder.embedding` arguments.
-
-        backbone_exit : dict
-        Dictionary with parameters for backbone_exit encoding: final increase in number of features.
-        See :meth:`~.EncoderDecoder.embedding` arguments.
-
         embedding : dict
         Same as :meth:`~.EncoderDecoder.embedding`. Default is to use ASPP.
+
+        decoder : dict
+        Dictionary with parameters for decoding of compressed representation.
+        See :meth:`~.EncoderDecoder.decoder` arguments. Default is to use bilinear upsampling.
     """
     @classmethod
     def default_config(cls):
         config = super().default_config()
         config['body/encoder'] = dict(base=None, num_stages=None)
-        config['body/encoder/downsample'] = dict(layout=None)
-        config['body/encoder/blocks'] = dict(base=Xception.block, filters=None, strides=2, combine_type='conv')
 
-        config['body/embeddings/common'] = dict(base=Xception.block)
-        config['body/backbone_middle'] = dict(num_stages=None, filters=None, strides=1, combine_type='sum')
-        config['body/backbone_exit'] = dict(num_stages=None, filters=None, strides=1,
-                                            depth_activation=True, combine_type='conv')
         config['body/embedding'] = dict(base=aspp)
-        config['body/embeddings/order'] = ['backbone_middle', 'backbone_exit', 'embedding']
 
         config['body/decoder'] = dict(skip=True, num_stages=None, factor=None)
         config['body/decoder/upsample'] = dict(layout='b')
@@ -57,28 +45,69 @@ class DeepLab(EncoderDecoder):
         return config
 
 
+class DeepLabX(DeepLab):
+    """ DeepLab v3+ model archtecture with Xception-based encoder.
 
-class DeepLab8(DeepLab):
-    """ DeepLab with output stride 8. """
+    Parameters
+    ----------
+    inputs : dict
+        Dictionary with 'images' (see :meth:`~.TFModel._make_inputs`)
+
+    body : dict
+        encoder : dict
+        Dictionary with parameters for entry encoding: downsampling of the inputs.
+        See :meth:`~.EncoderDecoder.encoder` arguments.
+
+            base : TFModel
+                Model class. Should implement ``make_encoder`` method. Default is to use Xception
+
+            entry : dict
+            Dictionary with parameters for entry encoding: downsampling of the inputs.
+            See :meth:`~.Xception` arguments.
+
+            middle : dict
+            Dictionary with parameters for middle encoding: thorough processing.
+            See :meth:`~.Xception` arguments.
+
+            exit : dict
+            Dictionary with parameters for exit encoding: final increase in number of features.
+            See :meth:`~.Xception` arguments.
+
+        embedding : dict
+        Same as :meth:`~.EncoderDecoder.embedding`. Default is to use ASPP.
+    """
+    @classmethod
+    def default_config(cls):
+        config = super().default_config()
+        config['body/encoder/base'] = Xception
+        config['body/encoder/entry'] = dict(num_stages=None, filters=None, strides=2, combine_type='conv')
+        config['body/encoder/middle'] = dict(num_stages=None, filters=None, strides=1, combine_type='sum')
+        config['body/encoder/exit'] = dict(num_stages=None, filters=None, strides=1, depth_activation=True, combine_type='conv')
+        config['body/encoder/downsample'] = dict(layout=None)
+
+        return config
+
+class DeepLabX8(DeepLabX):
+    """ DeepLab with output stride 8 and Xception-based encoder. """
     @classmethod
     def default_config(cls):
         config = super().default_config()
         config['initial_block'] = dict(layout='cnacna', filters=32, kernel_size=3, strides=1)
 
-        config['body/encoder/num_stages'] = 4
-        config['body/encoder/blocks/filters'] = [[64]*3,
+        config['body/encoder/entry/num_stages'] = 4
+        config['body/encoder/entry/filters'] = [[64]*3,
                                                  [128]*3,
                                                  [256]*3,
                                                  [728]*3]
-        config['body/encoder/blocks/strides'] = [2, 2, 2, 1]
+        config['body/encoder/entry/strides'] = [2, 2, 2, 1]
 
-        config['body/backbone_middle/num_stages'] = 8
-        config['body/backbone_middle/rate'] = 2 # not sure if actually needed
-        config['body/backbone_middle/filters'] = [[728]*3]*8
+        config['body/encoder/middle/num_stages'] = 8
+        config['body/encoder/middle/rate'] = 2 # not sure if actually needed
+        config['body/encoder/middle/filters'] = [[728]*3]*8
 
-        config['body/backbone_exit/num_stages'] = 2
-        config['body/backbone_exit/rate'] = [2, 4]
-        config['body/backbone_exit/filters'] = [[728, 1024, 1024],
+        config['body/encoder/exit/num_stages'] = 2
+        config['body/encoder/exit/rate'] = [2, 4]
+        config['body/encoder/exit/filters'] = [[728, 1024, 1024],
                                                 [1536, 1536, 2048]]
 
         config['body/embedding/rates'] = (12, 24, 36)
@@ -86,28 +115,27 @@ class DeepLab8(DeepLab):
         config['body/decoder'] = dict(skip=True, num_stages=4, factor=[1, 2, 1, 4])
         return config
 
-
-class DeepLab16(DeepLab):
-    """ DeepLab with output stride 16. """
+class DeepLabX16(DeepLabX):
+    """ DeepLab with output stride 8 and Xception-based encoder. """
     @classmethod
     def default_config(cls):
         config = super().default_config()
         config['initial_block'] = dict(layout='cnacna', filters=32, kernel_size=3, strides=1)
 
-        config['body/encoder/num_stages'] = 4
-        config['body/encoder/blocks/filters'] = [[64]*3,
+        config['body/encoder/entry/num_stages'] = 4
+        config['body/encoder/entry/filters'] = [[64]*3,
                                                  [128]*3,
                                                  [256]*3,
                                                  [728]*3]
-        config['body/encoder/blocks/strides'] = [2, 2, 2, 2]
+        config['body/encoder/entry/strides'] = [2, 2, 2, 2]
 
-        config['body/backbone_middle/num_stages'] = 16
-        config['body/backbone_middle/rate'] = 2 # not sure if actually needed
-        config['body/backbone_middle/filters'] = [[728]*3]*16
+        config['body/encoder/middle/num_stages'] = 16
+        config['body/encoder/middle/rate'] = 2 # not sure if actually needed
+        config['body/encoder/middle/filters'] = [[728]*3]*16
 
-        config['body/backbone_exit/num_stages'] = 2
-        config['body/backbone_exit/rate'] = [1, 2]
-        config['body/backbone_exit/filters'] = [[728, 1024, 1024],
+        config['body/encoder/exit/num_stages'] = 2
+        config['body/encoder/exit/rate'] = [2, 4]
+        config['body/encoder/exit/filters'] = [[728, 1024, 1024],
                                                 [1536, 1536, 2048]]
 
         config['body/embedding/rates'] = (6, 12, 18)
@@ -116,28 +144,30 @@ class DeepLab16(DeepLab):
         return config
 
 
-class DeepLabS(DeepLab):
-    """ DeepLab with output stride 16. Smaller than the others. """
+class DeepLabXS(DeepLabX):
+    """ DeepLab with output stride 16 and Xception-based encoder.
+        Smaller than the others and is used for testing purposes.
+    """
     @classmethod
     def default_config(cls):
         config = super().default_config()
-        config['initial_block'] = dict(layout='cna', filters=32, kernel_size=3, strides=1)
+        config['initial_block'] = dict(layout='cnacna', filters=32, kernel_size=3, strides=1)
 
-        config['body/encoder/num_stages'] = 4
-        config['body/encoder/blocks/filters'] = [[6]*3,
+        config['body/encoder/entry/num_stages'] = 4
+        config['body/encoder/entry/filters'] = [[6]*3,
                                                  [1]*3,
                                                  [2]*3,
                                                  [7]*3]
-        config['body/encoder/blocks/strides'] = [2, 2, 2, 2]
+        config['body/encoder/entry/strides'] = [2, 2, 2, 2]
 
-        config['body/backbone_middle/num_stages'] = 4
-        config['body/backbone_middle/rate'] = 2 # not sure if actually needed
-        config['body/backbone_middle/filters'] = [[7]*3]*4
+        config['body/encoder/middle/num_stages'] = 4
+        config['body/encoder/middle/rate'] = 2 # not sure if actually needed
+        config['body/encoder/middle/filters'] = [[7]*3]*4
 
-        config['body/backbone_exit/num_stages'] = 2
-        config['body/backbone_exit/rate'] = [2, 4]
-        config['body/backbone_exit/filters'] = [[7, 10, 10],
-                                                [10, 10, 12]]
+        config['body/encoder/exit/num_stages'] = 2
+        config['body/encoder/exit/rate'] = [2, 4]
+        config['body/encoder/exit/filters'] = [[7, 10, 10],
+                                                [15, 15, 20]]
 
         config['body/embedding/rates'] = (6, 12, 18)
 

--- a/batchflow/models/tf/deeplab.py
+++ b/batchflow/models/tf/deeplab.py
@@ -13,7 +13,7 @@ from . import EncoderDecoder, Xception
 
 class DeepLab(EncoderDecoder):
     """ DeepLab v3+ model archtecture.
-    By default, inpu is encoded with Xception backbone (entry, middle and exit flows),
+    By default, input is encoded with Xception backbone (entry, backbone_middle and backbone_exit flows),
     then worked via Atrous Spatial Pyramid Pooling layer, and, finally, restored to original
     spatial size with simple yet effective decoder module.
 
@@ -27,12 +27,12 @@ class DeepLab(EncoderDecoder):
         Dictionary with parameters for entry encoding: downsampling of the inputs.
         See :meth:`~.EncoderDecoder.encoder` arguments.
 
-        middle : dict
-        Dictionary with parameters for middle encoding: thorough processing.
+        backbone_middle : dict
+        Dictionary with parameters for backbone_middle encoding: thorough processing.
         See :meth:`~.EncoderDecoder.embedding` arguments.
 
-        exit : dict
-        Dictionary with parameters for exit encoding: final increase in number of features.
+        backbone_exit : dict
+        Dictionary with parameters for backbone_exit encoding: final increase in number of features.
         See :meth:`~.EncoderDecoder.embedding` arguments.
 
         embedding : dict
@@ -41,17 +41,15 @@ class DeepLab(EncoderDecoder):
     @classmethod
     def default_config(cls):
         config = super().default_config()
-        config['body/entry'] = dict(base=None, num_stages=None)
-        config['body/entry/downsample'] = dict(layout=None)
-        config['body/entry/blocks'] = dict(base=Xception.block, filters=None, strides=2, combine_type='conv')
+        config['body/encoder'] = dict(base=None, num_stages=None)
+        config['body/encoder/downsample'] = dict(layout=None)
+        config['body/encoder/blocks'] = dict(base=Xception.block, filters=None, strides=2, combine_type='conv')
 
-        config['body/middle'] = dict(base=Xception.block, num_stages=None,
-                                     filters=None, strides=1, combine_type='sum')
-
-        config['body/exit'] = dict(base=Xception.block, num_stages=None,
-                                   filters=None, strides=1, depth_activation=True, combine_type='conv')
-
+        config['body/embedding_common'] = dict(base=Xception.block)
+        config['body/backbone_middle'] = dict(num_stages=None, filters=None, strides=1, combine_type='sum')
+        config['body/backbone_exit'] = dict(num_stages=None, filters=None, strides=1, depth_activation=True, combine_type='conv')
         config['body/embedding'] = dict(base=aspp)
+        config['body/embedding_order'] = ['backbone_middle', 'backbone_exit', 'embedding']
 
         config['body/decoder'] = dict(skip=True, num_stages=None, factor=None)
         config['body/decoder/upsample'] = dict(layout='b')
@@ -59,34 +57,6 @@ class DeepLab(EncoderDecoder):
         config['head'] = dict(layout='c', kernel_size=1)
         return config
 
-
-    @classmethod
-    def body(cls, inputs, name='body', **kwargs):
-        """ Create encoder, embedding and decoder. """
-        kwargs = cls.fill_params('body', **kwargs)
-        entry = kwargs.pop('entry')
-        middle = kwargs.pop('middle')
-        exit = kwargs.pop('exit')
-        embedding = kwargs.pop('embedding')
-        decoder = kwargs.pop('decoder')
-
-        with tf.variable_scope(name):
-            # Entry flow: transition down
-            encoder_outputs = cls.encoder(inputs, name='entry', **entry, **kwargs)
-
-            # Middle flow: thorough processing without changing neither spatial resolution, nor number of filters
-            middle = cls.embedding(encoder_outputs[-1], name='middle', **middle, **kwargs)
-
-            # Exit flow: increase amount of features maps
-            exit = cls.embedding(middle, name='exit', **exit, **kwargs)
-
-            # Bottleneck: ASPP
-            x = cls.embedding(exit, **embedding, **kwargs)
-            encoder_outputs.append(x)
-
-            # Decoder: transition up
-            x = cls.decoder(encoder_outputs, **decoder, **kwargs)
-        return x
 
 
 class DeepLab8(DeepLab):
@@ -96,21 +66,21 @@ class DeepLab8(DeepLab):
         config = super().default_config()
         config['initial_block'] = dict(layout='cnacna', filters=32, kernel_size=3, strides=1)
 
-        config['body/entry/num_stages'] = 4
-        config['body/entry/blocks/filters'] = [[64]*3,
+        config['body/encoder/num_stages'] = 4
+        config['body/encoder/blocks/filters'] = [[64]*3,
                                                [128]*3,
                                                [256]*3,
                                                [728]*3]
-        config['body/entry/blocks/strides'] = [2, 2, 2, 1]
+        config['body/encoder/blocks/strides'] = [2, 2, 2, 1]
 
-        config['body/middle/num_stages'] = 8
-        config['body/middle/rate'] = 2 # not sure if actually needed
-        config['body/middle/filters'] = [[728]*3]*8
+        config['body/backbone_middle/num_stages'] = 8
+        config['body/backbone_middle/rate'] = 2 # not sure if actually needed
+        config['body/backbone_middle/filters'] = [[728]*3]*8
 
-        config['body/exit/num_stages'] = 2
-        config['body/exit/rate'] = [2, 4]
-        config['body/exit/filters'] = [[728, 1024, 1024],
-                                       [1536, 1536, 2048]]
+        config['body/backbone_exit/num_stages'] = 2
+        config['body/backbone_exit/rate'] = [2, 4]
+        config['body/backbone_exit/filters'] = [[728, 1024, 1024],
+                                                [1536, 1536, 2048]]
 
         config['body/embedding/rates'] = (12, 24, 36)
 
@@ -125,21 +95,21 @@ class DeepLab16(DeepLab):
         config = super().default_config()
         config['initial_block'] = dict(layout='cnacna', filters=32, kernel_size=3, strides=1)
 
-        config['body/entry/num_stages'] = 4
-        config['body/entry/blocks/filters'] = [[64]*3,
+        config['body/encoder/num_stages'] = 4
+        config['body/encoder/blocks/filters'] = [[64]*3,
                                                [128]*3,
                                                [256]*3,
                                                [728]*3]
-        config['body/entry/blocks/strides'] = [2, 2, 2, 2]
+        config['body/encoder/blocks/strides'] = [2, 2, 2, 2]
 
-        config['body/middle/num_stages'] = 16
-        config['body/middle/rate'] = 2 # not sure if actually needed
-        config['body/middle/filters'] = [[728]*3]*16
+        config['body/backbone_middle/num_stages'] = 16
+        config['body/backbone_middle/rate'] = 2 # not sure if actually needed
+        config['body/backbone_middle/filters'] = [[728]*3]*16
 
-        config['body/exit/num_stages'] = 2
-        config['body/exit/rate'] = [1, 2]
-        config['body/exit/filters'] = [[728, 1024, 1024],
-                                       [1536, 1536, 2048]]
+        config['body/backbone_exit/num_stages'] = 2
+        config['body/backbone_exit/rate'] = [1, 2]
+        config['body/backbone_exit/filters'] = [[728, 1024, 1024],
+                                                [1536, 1536, 2048]]
 
         config['body/embedding/rates'] = (6, 12, 18)
 
@@ -154,21 +124,21 @@ class DeepLabS(DeepLab):
         config = super().default_config()
         config['initial_block'] = dict(layout='cna', filters=32, kernel_size=3, strides=1)
 
-        config['body/entry/num_stages'] = 4
-        config['body/entry/blocks/filters'] = [[6]*3,
+        config['body/encoder/num_stages'] = 4
+        config['body/encoder/blocks/filters'] = [[6]*3,
                                                [1]*3,
                                                [2]*3,
                                                [7]*3]
-        config['body/entry/blocks/strides'] = [2, 2, 2, 2]
+        config['body/encoder/blocks/strides'] = [2, 2, 2, 2]
 
-        config['body/middle/num_stages'] = 4
-        config['body/middle/rate'] = 2 # not sure if actually needed
-        config['body/middle/filters'] = [[7]*3]*4
+        config['body/backbone_middle/num_stages'] = 4
+        config['body/backbone_middle/rate'] = 2 # not sure if actually needed
+        config['body/backbone_middle/filters'] = [[7]*3]*4
 
-        config['body/exit/num_stages'] = 2
-        config['body/exit/rate'] = [2, 4]
-        config['body/exit/filters'] = [[7, 10, 10],
-                                       [10, 10, 12]]
+        config['body/backbone_exit/num_stages'] = 2
+        config['body/backbone_exit/rate'] = [2, 4]
+        config['body/backbone_exit/filters'] = [[7, 10, 10],
+                                                [10, 10, 12]]
 
         config['body/embedding/rates'] = (6, 12, 18)
 

--- a/batchflow/models/tf/deeplab.py
+++ b/batchflow/models/tf/deeplab.py
@@ -4,10 +4,8 @@ Liang-Chieh Chen, Yukun Zhu, George Papandreou, Florian Schroff, Hartwig Adam.
 Convolution for Semantic Image Segmentation
 <https://arxiv.org/abs/1802.02611>`_"
 """
-import tensorflow as tf
-
-from .layers import aspp
 from . import EncoderDecoder, Xception
+from .layers import aspp
 
 
 
@@ -47,7 +45,8 @@ class DeepLab(EncoderDecoder):
 
         config['body/embedding_common'] = dict(base=Xception.block)
         config['body/backbone_middle'] = dict(num_stages=None, filters=None, strides=1, combine_type='sum')
-        config['body/backbone_exit'] = dict(num_stages=None, filters=None, strides=1, depth_activation=True, combine_type='conv')
+        config['body/backbone_exit'] = dict(num_stages=None, filters=None, strides=1,
+                                            depth_activation=True, combine_type='conv')
         config['body/embedding'] = dict(base=aspp)
         config['body/embedding_order'] = ['backbone_middle', 'backbone_exit', 'embedding']
 
@@ -68,9 +67,9 @@ class DeepLab8(DeepLab):
 
         config['body/encoder/num_stages'] = 4
         config['body/encoder/blocks/filters'] = [[64]*3,
-                                               [128]*3,
-                                               [256]*3,
-                                               [728]*3]
+                                                 [128]*3,
+                                                 [256]*3,
+                                                 [728]*3]
         config['body/encoder/blocks/strides'] = [2, 2, 2, 1]
 
         config['body/backbone_middle/num_stages'] = 8
@@ -97,9 +96,9 @@ class DeepLab16(DeepLab):
 
         config['body/encoder/num_stages'] = 4
         config['body/encoder/blocks/filters'] = [[64]*3,
-                                               [128]*3,
-                                               [256]*3,
-                                               [728]*3]
+                                                 [128]*3,
+                                                 [256]*3,
+                                                 [728]*3]
         config['body/encoder/blocks/strides'] = [2, 2, 2, 2]
 
         config['body/backbone_middle/num_stages'] = 16
@@ -126,9 +125,9 @@ class DeepLabS(DeepLab):
 
         config['body/encoder/num_stages'] = 4
         config['body/encoder/blocks/filters'] = [[6]*3,
-                                               [1]*3,
-                                               [2]*3,
-                                               [7]*3]
+                                                 [1]*3,
+                                                 [2]*3,
+                                                 [7]*3]
         config['body/encoder/blocks/strides'] = [2, 2, 2, 2]
 
         config['body/backbone_middle/num_stages'] = 4

--- a/batchflow/models/tf/deeplab.py
+++ b/batchflow/models/tf/deeplab.py
@@ -4,7 +4,7 @@ Liang-Chieh Chen, Yukun Zhu, George Papandreou, Florian Schroff, Hartwig Adam.
 Convolution for Semantic Image Segmentation
 <https://arxiv.org/abs/1802.02611>`_"
 """
-from . import EncoderDecoder, Xception
+from . import EncoderDecoder, Xception, MobileNet
 from .layers import aspp
 
 
@@ -45,6 +45,7 @@ class DeepLab(EncoderDecoder):
         return config
 
 
+
 class DeepLabX(DeepLab):
     """ DeepLab v3+ model archtecture with Xception-based encoder.
 
@@ -82,9 +83,9 @@ class DeepLabX(DeepLab):
         config['body/encoder/base'] = Xception
         config['body/encoder/entry'] = dict(num_stages=None, filters=None, strides=2, combine_type='conv')
         config['body/encoder/middle'] = dict(num_stages=None, filters=None, strides=1, combine_type='sum')
-        config['body/encoder/exit'] = dict(num_stages=None, filters=None, strides=1, depth_activation=True, combine_type='conv')
+        config['body/encoder/exit'] = dict(num_stages=None, filters=None, strides=1,
+                                           depth_activation=True, combine_type='conv')
         config['body/encoder/downsample'] = dict(layout=None)
-
         return config
 
 class DeepLabX8(DeepLabX):
@@ -96,9 +97,9 @@ class DeepLabX8(DeepLabX):
 
         config['body/encoder/entry/num_stages'] = 4
         config['body/encoder/entry/filters'] = [[64]*3,
-                                                 [128]*3,
-                                                 [256]*3,
-                                                 [728]*3]
+                                                [128]*3,
+                                                [256]*3,
+                                                [728]*3]
         config['body/encoder/entry/strides'] = [2, 2, 2, 1]
 
         config['body/encoder/middle/num_stages'] = 8
@@ -108,7 +109,7 @@ class DeepLabX8(DeepLabX):
         config['body/encoder/exit/num_stages'] = 2
         config['body/encoder/exit/rate'] = [2, 4]
         config['body/encoder/exit/filters'] = [[728, 1024, 1024],
-                                                [1536, 1536, 2048]]
+                                               [1536, 1536, 2048]]
 
         config['body/embedding/rates'] = (12, 24, 36)
 
@@ -124,9 +125,9 @@ class DeepLabX16(DeepLabX):
 
         config['body/encoder/entry/num_stages'] = 4
         config['body/encoder/entry/filters'] = [[64]*3,
-                                                 [128]*3,
-                                                 [256]*3,
-                                                 [728]*3]
+                                                [128]*3,
+                                                [256]*3,
+                                                [728]*3]
         config['body/encoder/entry/strides'] = [2, 2, 2, 2]
 
         config['body/encoder/middle/num_stages'] = 16
@@ -136,7 +137,7 @@ class DeepLabX16(DeepLabX):
         config['body/encoder/exit/num_stages'] = 2
         config['body/encoder/exit/rate'] = [2, 4]
         config['body/encoder/exit/filters'] = [[728, 1024, 1024],
-                                                [1536, 1536, 2048]]
+                                               [1536, 1536, 2048]]
 
         config['body/embedding/rates'] = (6, 12, 18)
 
@@ -155,9 +156,9 @@ class DeepLabXS(DeepLabX):
 
         config['body/encoder/entry/num_stages'] = 4
         config['body/encoder/entry/filters'] = [[6]*3,
-                                                 [1]*3,
-                                                 [2]*3,
-                                                 [7]*3]
+                                                [1]*3,
+                                                [2]*3,
+                                                [7]*3]
         config['body/encoder/entry/strides'] = [2, 2, 2, 2]
 
         config['body/encoder/middle/num_stages'] = 4
@@ -167,9 +168,15 @@ class DeepLabXS(DeepLabX):
         config['body/encoder/exit/num_stages'] = 2
         config['body/encoder/exit/rate'] = [2, 4]
         config['body/encoder/exit/filters'] = [[7, 10, 10],
-                                                [15, 15, 20]]
+                                               [15, 15, 20]]
 
         config['body/embedding/rates'] = (6, 12, 18)
 
         config['body/decoder'] = dict(skip=True, num_stages=4, factor=[1, 4, 1, 4])
         return config
+
+
+
+class DeepLabM(DeepLab):
+    """ DeepLab v3+ model archtecture with MobileNet-based encoder. """
+    pass

--- a/batchflow/models/tf/deeplab.py
+++ b/batchflow/models/tf/deeplab.py
@@ -60,28 +60,6 @@ class DeepLab(EncoderDecoder):
         return config
 
 
-    def build_config(self, names=None):
-        config = super().build_config(names)
-
-        entry_filters = config.get('body/entry/blocks/filters')
-        if entry_filters is None:
-            raise ValueError('Specify filters for the entry flow.')
-
-        middle_filters = config.get('body/middle/filters')
-        if middle_filters is None:
-            raise ValueError('Specify filters for the middle flow.')
-        if isinstance(middle_filters, list):
-            if isinstance(middle_filters[0], list):
-                config['body/middle/num_stages'] = len(middle_filters)
-            else:
-                middle_num = config.get('body/middle/num_stages')
-                if middle_num is not None:
-                    config['body/middle/filters'] = [middle_filters] * middle_num
-                else:
-                    raise ValueError('Specify number of stages for the middle')
-        return config
-
-
     @classmethod
     def body(cls, inputs, name='body', **kwargs):
         """ Create encoder, embedding and decoder. """

--- a/batchflow/models/tf/deeplab.py
+++ b/batchflow/models/tf/deeplab.py
@@ -38,9 +38,8 @@ class DeepLab(EncoderDecoder):
 
         config['body/embedding'] = dict(base=aspp)
 
-        config['body/decoder'] = dict(skip=True, num_stages=None, factor=None)
         config['body/decoder/upsample'] = dict(layout='b')
-        config['body/decoder/blocks'] = dict(base=cls.block)
+
         config['head'] = dict(layout='c', kernel_size=1)
         return config
 
@@ -117,7 +116,7 @@ class DeepLabX8(DeepLabX):
         return config
 
 class DeepLabX16(DeepLabX):
-    """ DeepLab with output stride 8 and Xception-based encoder. """
+    """ DeepLab with output stride 16 and Xception-based encoder. """
     @classmethod
     def default_config(cls):
         config = super().default_config()

--- a/batchflow/models/tf/deeplab.py
+++ b/batchflow/models/tf/deeplab.py
@@ -43,12 +43,12 @@ class DeepLab(EncoderDecoder):
         config['body/encoder/downsample'] = dict(layout=None)
         config['body/encoder/blocks'] = dict(base=Xception.block, filters=None, strides=2, combine_type='conv')
 
-        config['body/embedding_common'] = dict(base=Xception.block)
+        config['body/embeddings/common'] = dict(base=Xception.block)
         config['body/backbone_middle'] = dict(num_stages=None, filters=None, strides=1, combine_type='sum')
         config['body/backbone_exit'] = dict(num_stages=None, filters=None, strides=1,
                                             depth_activation=True, combine_type='conv')
         config['body/embedding'] = dict(base=aspp)
-        config['body/embedding_order'] = ['backbone_middle', 'backbone_exit', 'embedding']
+        config['body/embeddings/order'] = ['backbone_middle', 'backbone_exit', 'embedding']
 
         config['body/decoder'] = dict(skip=True, num_stages=None, factor=None)
         config['body/decoder/upsample'] = dict(layout='b')

--- a/batchflow/models/tf/deeplab.py
+++ b/batchflow/models/tf/deeplab.py
@@ -12,8 +12,8 @@ from . import EncoderDecoder, Xception
 
 
 class DeepLab(EncoderDecoder):
-    """ DeepLab model archtecture.
-    Input is encoded through Xception backbone (entry, middle and exit flows),
+    """ DeepLab v3+ model archtecture.
+    By default, inpu is encoded with Xception backbone (entry, middle and exit flows),
     then worked via Atrous Spatial Pyramid Pooling layer, and, finally, restored to original
     spatial size with simple yet effective decoder module.
 

--- a/batchflow/models/tf/deeplab.py
+++ b/batchflow/models/tf/deeplab.py
@@ -179,4 +179,8 @@ class DeepLabXS(DeepLabX):
 
 class DeepLabM(DeepLab):
     """ DeepLab v3+ model archtecture with MobileNet-based encoder. """
-    pass
+    @classmethod
+    def default_config(cls):
+        config = super().default_config()
+        config['body/encoder/base'] = MobileNet
+        return config

--- a/batchflow/models/tf/deeplab.py
+++ b/batchflow/models/tf/deeplab.py
@@ -29,12 +29,14 @@ class DeepLab(EncoderDecoder):
 
         middle : dict
         Dictionary with parameters for middle encoding: thorough processing.
-        See :meth:`~.EncoderDecoder.encoder` arguments.
+        See :meth:`~.EncoderDecoder.embedding` arguments.
 
         exit : dict
         Dictionary with parameters for exit encoding: final increase in number of features.
-        See :meth:`~.EncoderDecoder.encoder` arguments.
+        See :meth:`~.EncoderDecoder.embedding` arguments.
 
+        embedding : dict
+        Same as :meth:`~.EncoderDecoder.embedding`. Default is to use ASPP.
     """
     @classmethod
     def default_config(cls):

--- a/batchflow/models/tf/deeplab.py
+++ b/batchflow/models/tf/deeplab.py
@@ -1,0 +1,197 @@
+"""
+Liang-Chieh Chen, Yukun Zhu, George Papandreou, Florian Schroff, Hartwig Adam.
+"`Encoder-Decoder with Atrous Separable
+Convolution for Semantic Image Segmentation
+<https://arxiv.org/abs/1802.02611>`_"
+"""
+import tensorflow as tf
+
+from .layers import aspp
+from . import EncoderDecoder, Xception
+
+
+
+class DeepLab(EncoderDecoder):
+    """ DeepLab model archtecture.
+    Input is encoded through Xception backbone (entry, middle and exit flows),
+    then worked via Atrous Spatial Pyramid Pooling layer, and, finally, restored to original
+    spatial size with simple yet effective decoder module.
+
+    Parameters
+    ----------
+    inputs : dict
+        Dictionary with 'images' (see :meth:`~.TFModel._make_inputs`)
+
+    body : dict
+        entry : dict
+        Dictionary with parameters for entry encoding: downsampling of the inputs.
+        See :meth:`~.EncoderDecoder.encoder` arguments.
+
+        middle : dict
+        Dictionary with parameters for middle encoding: thorough processing.
+        See :meth:`~.EncoderDecoder.encoder` arguments.
+
+        exit : dict
+        Dictionary with parameters for exit encoding: final increase in number of features.
+        See :meth:`~.EncoderDecoder.encoder` arguments.
+
+    """
+    @classmethod
+    def default_config(cls):
+        config = super().default_config()
+        config['body/entry'] = dict(base=None, num_stages=None)
+        config['body/entry/downsample'] = dict(layout=None)
+        config['body/entry/blocks'] = dict(base=Xception.block, filters=None, strides=2, combine_type='conv')
+
+
+        config['body/middle'] = dict(base=Xception.block, num_stages=None,
+                                     filters=None, strides=1, combine_type='sum')
+
+        config['body/exit'] = dict(base=Xception.block, num_stages=None,
+                                   filters=None, strides=1, depth_activation=True, combine_type='conv')
+
+        config['body/embedding'] = dict(base=aspp)
+
+        config['body/decoder'] = dict(skip=True, num_stages=None, factor=None)
+        config['body/decoder/upsample'] = dict(layout='b')
+        config['body/decoder/blocks'] = dict(base=cls.block)
+        config['head'] = dict(layout='c', kernel_size=1)
+        return config
+
+
+    def build_config(self, names=None):
+        config = super().build_config(names)
+
+        entry_filters = config.get('body/entry/blocks/filters')
+        if entry_filters is None:
+            raise ValueError('Specify filters for the entry flow.')
+
+        middle_filters = config.get('body/middle/filters')
+        if middle_filters is None:
+            raise ValueError('Specify filters for the middle flow.')
+        if isinstance(middle_filters, list):
+            if isinstance(middle_filters[0], list):
+                config['body/middle/num_stages'] = len(middle_filters)
+            else:
+                middle_num = config.get('body/middle/num_stages')
+                if middle_num is not None:
+                    config['body/middle/filters'] = [middle_filters] * middle_num
+                else:
+                    raise ValueError('Specify number of stages for the middle')
+        return config
+
+
+    @classmethod
+    def body(cls, inputs, name='body', **kwargs):
+        """ Create encoder, embedding and decoder. """
+        kwargs = cls.fill_params('body', **kwargs)
+        entry = kwargs.pop('entry')
+        middle = kwargs.pop('middle')
+        exit = kwargs.pop('exit')
+        embedding = kwargs.pop('embedding')
+        decoder = kwargs.pop('decoder')
+
+        with tf.variable_scope(name):
+            # Entry flow: transition down
+            encoder_outputs = cls.encoder(inputs, name='entry', **entry, **kwargs)
+
+            # Middle flow: thorough processing without changing neither spatial resolution, nor number of filters
+            middle = cls.embedding(encoder_outputs[-1], name='middle', **middle, **kwargs)
+
+            # Exit flow: increase amount of features maps
+            exit = cls.embedding(middle, name='exit', **exit, **kwargs)
+
+            # Bottleneck: ASPP
+            x = cls.embedding(exit, **embedding, **kwargs)
+            encoder_outputs.append(x)
+
+            # Decoder: transition up
+            x = cls.decoder(encoder_outputs, **decoder, **kwargs)
+        return x
+
+
+class DeepLab8(DeepLab):
+    """ DeepLab with output stride 8. """
+    @classmethod
+    def default_config(cls):
+        config = super().default_config()
+        config['initial_block']: dict(layout='cnacna', filters=[32], kernel_size=3, strides=1)
+
+        config['body/entry/num_stages'] = 4
+        config['body/entry/blocks/filters'] = [[64]*3,
+                                               [128]*3,
+                                               [256]*3,
+                                               [728]*3]
+        config['body/entry/blocks/strides'] = [2, 2, 2, 1]
+
+        config['body/middle/num_stages'] = 8
+        config['body/middle/rate'] = 2 # not sure if actually needed
+        config['body/middle/filters'] = [[728]*3]*8
+
+        config['body/exit/num_stages'] = 2
+        config['body/exit/rate'] = [2, 4]
+        config['body/exit/filters'] = [[728, 1024, 1024],
+                                       [1536, 1536, 2048]]
+
+        config['body/embedding/rates'] = (12, 24, 36)
+
+        config['body/decoder'] = dict(skip=True, num_stages=4, factor=[1, 2, 1, 4])
+        return config
+
+
+class DeepLab16(DeepLab):
+    """ DeepLab with output stride 16. """
+    @classmethod
+    def default_config(cls):
+        config = super().default_config()
+        config['initial_block']: dict(layout='cnacna', filters=[32], kernel_size=3, strides=1)
+
+        config['body/entry/num_stages'] = 4
+        config['body/entry/blocks/filters'] = [[64]*3,
+                                               [128]*3,
+                                               [256]*3,
+                                               [728]*3]
+        config['body/entry/blocks/strides'] = [2, 2, 2, 2]
+
+        config['body/middle/num_stages'] = 16
+        config['body/middle/rate'] = 2 # not sure if actually needed
+        config['body/middle/filters'] = [[728]*3]*16
+
+        config['body/exit/num_stages'] = 2
+        config['body/exit/rate'] = [1, 2]
+        config['body/exit/filters'] = [[728, 1024, 1024],
+                                       [1536, 1536, 2048]]
+
+        config['body/embedding/rates'] = (6, 12, 18)
+
+        config['body/decoder'] = dict(skip=True, num_stages=4, factor=[1, 4, 1, 4])
+        return config
+
+
+class DeepLabS(DeepLab):
+    """ DeepLab with output stride 16. Smaller than the others. """
+    @classmethod
+    def default_config(cls):
+        config = super().default_config()
+        config['initial_block']: dict(layout='cna', filters=[32], kernel_size=3, strides=1)
+
+        config['body/entry/num_stages'] = 4
+        config['body/entry/blocks/filters'] = [[6]*3,
+                                               [1]*3,
+                                               [2]*3,
+                                               [7]*3]
+        config['body/entry/blocks/strides'] = [2, 2, 2, 2]
+
+        config['body/middle/num_stages'] = 4
+        config['body/middle/rate'] = 2 # not sure if actually needed
+        config['body/middle/filters'] = [[7]*3]*4
+
+        config['body/exit/num_stages'] = 2
+        config['body/exit/rate'] = [2, 4]
+        config['body/exit/filters'] = [[7, 10, 10],
+                                       [10, 10, 12]]
+
+        config['body/embedding/rates'] = (6, 12, 18)
+
+        config['body/decoder'] = dict(skip=True, num_stages=4, factor=[1, 4, 1, 4])
+        return config

--- a/batchflow/models/tf/layers/__init__.py
+++ b/batchflow/models/tf/layers/__init__.py
@@ -2,7 +2,7 @@
 from .core import flatten, flatten2d, maxout, mip, xip, alpha_dropout
 from .conv_block import conv_block, upsample
 from .conv import conv1d_transpose, conv1d_transpose_nn, conv_transpose, \
-				  separable_conv, separable_conv_transpose, depthwise_conv
+				  separable_conv, separable_conv_transpose, depthwise_conv, depthwise_conv_transpose
 from .pooling import max_pooling, average_pooling, pooling, \
                      global_pooling, global_average_pooling, global_max_pooling, \
                      fractional_pooling

--- a/batchflow/models/tf/layers/__init__.py
+++ b/batchflow/models/tf/layers/__init__.py
@@ -1,7 +1,8 @@
 """ Custom tf layers and operations """
 from .core import flatten, flatten2d, maxout, mip, xip, alpha_dropout
 from .conv_block import conv_block, upsample
-from .conv import conv1d_transpose, conv1d_transpose_nn, conv_transpose, separable_conv, separable_conv_transpose
+from .conv import conv1d_transpose, conv1d_transpose_nn, conv_transpose, \
+				  separable_conv, separable_conv_transpose, depthwise_conv
 from .pooling import max_pooling, average_pooling, pooling, \
                      global_pooling, global_average_pooling, global_max_pooling, \
                      fractional_pooling

--- a/batchflow/models/tf/layers/pyramid.py
+++ b/batchflow/models/tf/layers/pyramid.py
@@ -179,7 +179,7 @@ def aspp(inputs, layout='cna', filters=None, kernel_size=3, rates=(6, 12, 18), i
 
         for level in rates:
             x = conv_block(inputs, layout, filters=filters, kernel_size=kernel_size, dilation_rate=level,
-                           name='conv-%d' % level, **kwargs)
+                           name='atrous_conv-%d' % level, **kwargs)
             layers.append(x)
 
         x = pyramid_pooling(inputs, filters=filters, pyramid=image_level_features,

--- a/batchflow/models/tf/layers/pyramid.py
+++ b/batchflow/models/tf/layers/pyramid.py
@@ -6,7 +6,7 @@ from . import conv_block, upsample
 
 
 def pyramid_pooling(inputs, layout='cna', filters=None, kernel_size=1, pool_op='mean', pyramid=(0, 1, 2, 3, 6),
-                    reshape_to_vector=False, name='psp', **kwargs):
+                    flatten=False, name='psp', **kwargs):
     """ Pyramid Pooling module
 
     Zhao H. et al. "`Pyramid Scene Parsing Network <https://arxiv.org/abs/1612.01105>`_"
@@ -26,7 +26,7 @@ def pyramid_pooling(inputs, layout='cna', filters=None, kernel_size=1, pool_op='
     pyramid : tuple of int
         the number of feature regions in each dimension, default is (0, 1, 2, 3, 6).
         `0` is used to include `inputs` into the output tensor.
-    reshape_to_vector : bool
+    flatten : bool
         if True, then the output is reshaped to a vector of constant size
         if False, spatial shape of the inputs is preserved
     name : str
@@ -65,7 +65,7 @@ def pyramid_pooling(inputs, layout='cna', filters=None, kernel_size=1, pool_op='
                                name='conv-%d' % level, **kwargs)
 
                 # Output either vector with fixed size or tensor with fixed spatial dimensions
-                if reshape_to_vector:
+                if flatten:
                     x = tf.reshape(x, shape=(-1, level*level*filters),
                                    name='reshape-%d' % level)
                     concat_axis = -1
@@ -176,7 +176,7 @@ def aspp(inputs, layout='cna', filters=None, kernel_size=3, rates=(6, 12, 18), i
 
         for level in rates:
             x = conv_block(inputs, layout, filters=filters, kernel_size=kernel_size, dilation_rate=level,
-                           name='atrous_conv-%d' % level, **kwargs)
+                           name='conv-%d' % level, **kwargs)
             layers.append(x)
 
         x = pyramid_pooling(inputs, filters=filters, pyramid=image_level_features,

--- a/batchflow/models/tf/layers/pyramid.py
+++ b/batchflow/models/tf/layers/pyramid.py
@@ -5,7 +5,7 @@ import tensorflow as tf
 from . import conv_block, upsample
 
 
-def pyramid_pooling(inputs, layout='cna', filters=None, kernel_size=1,pool_op='mean', pyramid=(0, 1, 2, 3, 6),
+def pyramid_pooling(inputs, layout='cna', filters=None, kernel_size=1, pool_op='mean', pyramid=(0, 1, 2, 3, 6),
                     reshape_to_vector=False, name='psp', **kwargs):
     """ Pyramid Pooling module
 
@@ -75,7 +75,7 @@ def pyramid_pooling(inputs, layout='cna', filters=None, kernel_size=1,pool_op='m
                     concat_axis = axis
 
             layers.append(x)
-        x = tf.concat(layers, axis=axis, name='concat')
+        x = tf.concat(layers, axis=concat_axis, name='concat')
     return x
 
 def _static_pyramid_pooling(inputs, spatial_shape, level, pool_op, **kwargs):
@@ -93,11 +93,8 @@ def _dynamic_pyramid_pooling(inputs, level, pool_op, num_channels, data_format):
         h_axis, w_axis = -2, -1
 
     inputs_shape = tf.shape(inputs)
-    h = tf.cast(tf.gather(inputs_shape, h_axis), tf.int32)
-    w = tf.cast(tf.gather(inputs_shape, w_axis), tf.int32)
-
-    h_float = tf.cast(h, tf.float32)
-    w_float = tf.cast(w, tf.float32)
+    h_float = tf.cast(tf.gather(inputs_shape, h_axis), tf.float32)
+    w_float = tf.cast(tf.gather(inputs_shape, w_axis), tf.float32)
 
     if pool_op == 'mean':
         pooling_op = tf.reduce_mean

--- a/batchflow/models/tf/xception.py
+++ b/batchflow/models/tf/xception.py
@@ -1,0 +1,105 @@
+"""
+François Chollet. "`Xception: Deep Learning with Depthwise Separable Convolutions
+<https://arxiv.org/abs/1610.02357>`_"
+"""
+
+import tensorflow as tf
+
+from .layers import conv_block
+from . import TFModel
+
+
+
+class Xception(TFModel):
+    """ Non-empty. """
+
+    @classmethod
+    def default_config(cls):
+        config = TFModel.default_config()
+        return config
+
+    def build_config(self, names=None):
+        config = super().build_config(names)
+        config['head/targets'] = self.get_from_attr('targets')
+        return config
+
+    @classmethod
+    def block(cls, inputs, filters, combine_type='sum', name=None, **kwargs):
+        """ Basic building block of the architecture.
+        For details see figure 5 in the article.
+
+        Parameters
+        ----------
+        filters : tuple of 3 ints
+        """
+        strides = (1, kwargs.get('strides', 1), 1)
+        x = inputs
+
+        with tf.variable_scope(name):
+            # Prepare skip-connection
+            if combine_type == 'sum':
+                shortcut = inputs
+            elif combine_type == 'conv':
+                shortcut = conv_block(inputs, 'cn', filters[-1], kernel_size=1,
+                                      strides=strides[1], name='shortcut')
+
+            # Three consecutive separable blocks
+            for i, filter_ in enumerate(filters):
+                x = cls.separable_block(x, filter_, strides=strides[i],
+                                        name='separable_conv-{}'.format(i), **kwargs)
+
+            outputs = tf.add_n([x, shortcut])
+        return outputs
+
+    @classmethod
+    def separable_block(cls, inputs, filters, kernel_size=3, strides=1, rate=1,
+                        depth_activation=False, name=None, **kwargs):
+        """ Separable convolution, followed by pointwise convolution with batch-normalization in-between. """
+        layout = 'nacna' if depth_activation else 'ncn'
+        data_format = kwargs.get('data_format')
+
+        with tf.variable_scope(name):
+            x = cls._depthwise_conv(inputs, kernel_size=kernel_size, strides=strides, dilation_rate=rate,
+                                    data_format=data_format, padding='same', name='depthwise')
+
+            x = conv_block(x, layout, filters=filters, kernel_size=1, strides=strides, **kwargs)
+        return x
+
+
+    @classmethod
+    def _depthwise_conv(cls, inputs, depth_multiplier=1, name=None, **kwargs):
+        data_format = kwargs.get('data_format')
+
+        # Parse shapes
+        inputs_shape = inputs.get_shape().as_list()
+        dim = inputs.shape.ndims - 2
+        axis = -1 if data_format == 'channels_last' else 1
+        size = [-1] * (dim + 2)
+        size[axis] = 1
+        channels_in = inputs_shape[axis]
+
+        # Loop through feature maps
+        depthwise_layers = []
+        for channel in range(channels_in):
+            start = [0] * (dim + 2)
+            start[axis] = channel
+
+            input_slice = tf.slice(inputs, start, size)
+            _kwargs = {**kwargs, 'inputs': input_slice, 'filters': depth_multiplier, 'name': 'slice-%d' % channel}
+
+            slice_conv = tf.layers.conv2d(**_kwargs)
+            depthwise_layers.append(slice_conv)
+
+        # Concatenate the per-channel convolutions along the channel dimension.
+        depthwise_conv = tf.concat(depthwise_layers, axis=axis, name=name)
+        return depthwise_conv
+
+
+    @classmethod
+    def body(cls, inputs, name='body', **kwargs):
+        pass
+
+
+    @classmethod
+    def head(cls, inputs, targets, name='head', **kwargs):
+        pass

--- a/batchflow/models/tf/xception.py
+++ b/batchflow/models/tf/xception.py
@@ -5,7 +5,7 @@ François Chollet. "`Xception: Deep Learning with Depthwise Separable Convolutio
 
 import tensorflow as tf
 
-from .layers import conv_block
+from .layers import conv_block, depthwise_conv
 from . import TFModel
 
 
@@ -133,21 +133,10 @@ class Xception(TFModel):
         data_format = kwargs.get('data_format')
 
         with tf.variable_scope(name):
-            x = cls._depthwise_conv(inputs, kernel_size=kernel_size, strides=strides, dilation_rate=rate,
-                                    data_format=data_format, padding='same', name='depthwise')
-
+            x = depthwise_conv(inputs, kernel_size=kernel_size, strides=strides, dilation_rate=rate,
+                               data_format=data_format, padding='same', name='depthwise')
             x = conv_block(x, layout, filters=filters, kernel_size=1, **kwargs)
         return x
-
-
-    @classmethod
-    def _depthwise_conv(cls, inputs, depth_multiplier=1, name='depthwise_conv', **kwargs):
-        data_format = kwargs.get('data_format')
-        filters = cls.num_channels(inputs, data_format)
-        depthwise_conv = tf.keras.layers.SeparableConv2D(filters=filters,
-                                                         depth_multiplier=depth_multiplier,
-                                                         name=name, **kwargs)(inputs)
-        return depthwise_conv
 
 
     @classmethod

--- a/batchflow/models/tf/xception.py
+++ b/batchflow/models/tf/xception.py
@@ -63,7 +63,7 @@ class Xception(TFModel):
             x = inputs
 
             # Entry flow: downsample the inputs
-            with tf.variable_scope('entry_flow'):
+            with tf.variable_scope('entry'):
                 entry_stages = entry.pop('num_stages', 0)
                 for i in range(entry_stages):
                     with tf.variable_scope('group-'+str(i)):
@@ -72,20 +72,20 @@ class Xception(TFModel):
                         x = tf.identity(x, name='output')
 
             # Middle flow: thorough processing
-            with tf.variable_scope('middle_flow'):
+            with tf.variable_scope('middle'):
                 middle_stages = middle.pop('num_stages', 0)
                 for i in range(middle_stages):
                     args = {**kwargs, **middle, **unpack_args(middle, i, middle_stages)}
                     x = cls.block(x, name='block-'+str(i), **args)
 
             # Exit flow: final increase in number of feature maps
-            with tf.variable_scope('exit_flow'):
+            with tf.variable_scope('exit'):
                 exit_stages = exit.pop('num_stages', 0)
                 for i in range(exit_stages):
                     args = {**kwargs, **exit, **unpack_args(exit, i, exit_stages)}
                     x = cls.block(x, name='block-'+str(i), **args)
 
-            with tf.variable_scope('entry_flow/group-'+str(entry_stages)):
+            with tf.variable_scope('entry/group-'+str(entry_stages)):
                 x = tf.identity(x, name='output')
         return x
 
@@ -153,7 +153,7 @@ class Xception(TFModel):
             scope = tf.get_default_graph().get_name_scope()
             encoder_tensors = [inputs]
             for i in range(steps):
-                tensor_name = scope + '/body/entry_flow/group-'+str(i) + '/output:0'
+                tensor_name = scope + '/body/entry/group-'+str(i) + '/output:0'
                 x = tf.get_default_graph().get_tensor_by_name(tensor_name)
                 encoder_tensors.append(x)
         return encoder_tensors

--- a/batchflow/models/tf/xception.py
+++ b/batchflow/models/tf/xception.py
@@ -11,7 +11,28 @@ from . import TFModel
 
 
 class Xception(TFModel):
-    """ Non-empty. """
+    """ Xception model architecture.
+
+    Parameters
+    ----------
+    inputs : dict
+        Dictionary with 'images' (see :meth:`~.TFModel._make_inputs`).
+
+    body : dict
+        entry, middle, exit : dict
+        Dictionary with parameters for entry encoding: downsampling of the inputs.
+            num_stages : int
+                Number of `block`'s in the respective flow.
+            filters : list of sequences of 3 ints
+                Number of filters inside for individual `block`.
+            strides : int or list of ints
+                Stride of the middle `separable_block` inside `block`.
+            depth_activation : bool or list of bools
+                Whether to use activation between depthwise and pointwise convolutions.
+            combine_type : {'sum', 'conv'}
+                Whether to use convolution for skip-connections inside `separable_block` or
+                just sum skip and output.
+    """
 
     @classmethod
     def default_config(cls):
@@ -31,7 +52,14 @@ class Xception(TFModel):
 
 
     @classmethod
+    def slice_dict(cls, dictionary, idx):
+        return {key: value[idx] for key, value in dictionary.items()
+                if isinstance(value, list)}
+
+
+    @classmethod
     def body(cls, inputs, name='body', **kwargs):
+        """ Entry, middle and exit flows consequently. """
         kwargs = cls.fill_params('body', **kwargs)
         entry = kwargs.pop('entry')
         middle = kwargs.pop('middle')
@@ -43,34 +71,24 @@ class Xception(TFModel):
             # Entry flow: downsample the inputs
             with tf.variable_scope('entry_flow'):
                 entry_stages = entry.pop('num_stages', 0)
-                entry_filters = entry.pop('filters')
-                entry_args = {**kwargs, **entry}
                 for i in range(entry_stages):
-                    x = cls.block(x, filters=entry_filters[i],
-                                  name='block-'+str(i), **entry_args)
-                print('DONE ENTRY')
+                    args = {**kwargs, **entry, **cls.slice_dict(entry, i)}
+                    x = cls.block(x, name='block-'+str(i), **args)
 
-            # Entry flow: downsample the inputs
+            # Middle flow: thorough processing
             with tf.variable_scope('middle_flow'):
                 middle_stages = middle.pop('num_stages', 0)
-                middle_filters = middle.pop('filters')
-                middle_args = {**kwargs, **middle}
                 for i in range(middle_stages):
-                    x = cls.block(x, filters=middle_filters[i],
-                                  name='block-'+str(i), **middle_args)
-                print('DONE MIDDLE')
+                    args = {**kwargs, **middle, **cls.slice_dict(middle, i)}
+                    x = cls.block(x, name='block-'+str(i), **args)
 
-            # Entry flow: downsample the inputs
+            # Exit flow: final increase in number of feature maps
             with tf.variable_scope('exit_flow'):
                 exit_stages = exit.pop('num_stages', 0)
-                exit_filters = exit.pop('filters')
-                exit_args = {**kwargs, **exit}
                 for i in range(exit_stages):
-                    x = cls.block(x, filters=exit_filters[i],
-                                  name='block-'+str(i), **exit_args)
-                print('DONE EXIT')
+                    args = {**kwargs, **exit, **cls.slice_dict(exit, i)}
+                    x = cls.block(x, name='block-'+str(i), **args)
         return x
-
 
 
     @classmethod
@@ -102,6 +120,7 @@ class Xception(TFModel):
             outputs = tf.add_n([x, shortcut])
         return outputs
 
+
     @classmethod
     def separable_block(cls, inputs, filters, kernel_size=3, strides=1, rate=1,
                         depth_activation=False, name='separable_block', **kwargs):
@@ -115,6 +134,7 @@ class Xception(TFModel):
 
             x = conv_block(x, layout, filters=filters, kernel_size=1, **kwargs)
         return x
+
 
     @classmethod
     def _depthwise_conv(cls, inputs, depth_multiplier=1, name='depthwise_conv', **kwargs):
@@ -145,8 +165,46 @@ class Xception(TFModel):
         return depthwise_conv
 
 
+class Xception41(Xception):
+    """ Xception-41 architecture."""
+    @classmethod
+    def default_config(cls):
+        config = super().default_config()
+        config['body/entry'] = dict(num_stages=3,
+                                    filters=[[128]*3,
+                                             [256]*3,
+                                             [728]*3])
+
+        config['body/middle'] = dict(num_stages=8,
+                                     filters=[[728]*3]*8)
+
+        config['body/exit'] = dict(num_stages=2, strides=[2, 1],
+                                   filters=[[728, 1024, 1024],
+                                            [1536, 1536, 2048]])
+        return config
+
+
+class Xception64(Xception):
+    """ Xception-64 architecture."""
+    @classmethod
+    def default_config(cls):
+        config = super().default_config()
+        config['body/entry'] = dict(num_stages=3,
+                                    filters=[[128]*3,
+                                             [256]*3,
+                                             [728]*3])
+
+        config['body/middle'] = dict(num_stages=16,
+                                     filters=[[728]*3]*16)
+
+        config['body/exit'] = dict(num_stages=2, strides=[2, 1],
+                                   filters=[[728, 1024, 1024],
+                                            [1536, 1536, 2048]])
+        return config
+
 
 class XceptionS(Xception):
+    """ Small version of Xception architecture."""
     @classmethod
     def default_config(cls):
         config = super().default_config()
@@ -155,9 +213,7 @@ class XceptionS(Xception):
                                              [12]*3,])
         config['body/middle'] = dict(num_stages=2,
                                      filters=[[12]*3]*2)
-        config['body/exit'] = dict(num_stages=2,
+        config['body/exit'] = dict(num_stages=2, strides=[2, 1],
                                    filters=[[12]*3,
                                             [15]*3,])
         return config
-
-

--- a/batchflow/models/tf/xception.py
+++ b/batchflow/models/tf/xception.py
@@ -16,6 +16,9 @@ class Xception(TFModel):
     @classmethod
     def default_config(cls):
         config = TFModel.default_config()
+        config['body/entry'] = dict(num_stages=None, filters=None, strides=2, combine_type='conv')
+        config['body/middle'] = dict(num_stages=None, filters=None, strides=1, combine_type='sum')
+        config['body/exit'] = dict(num_stages=None, filters=None, strides=1, depth_activation=True, combine_type='conv')
         return config
 
     def build_config(self, names=None):
@@ -26,8 +29,52 @@ class Xception(TFModel):
             config['head/filters'] = self.num_classes('targets')
         return config
 
+
     @classmethod
-    def block(cls, inputs, filters, combine_type='sum', name=None, **kwargs):
+    def body(cls, inputs, name='body', **kwargs):
+        kwargs = cls.fill_params('body', **kwargs)
+        entry = kwargs.pop('entry')
+        middle = kwargs.pop('middle')
+        exit = kwargs.pop('exit')
+
+        with tf.variable_scope(name):
+            x = inputs
+
+            # Entry flow: downsample the inputs
+            with tf.variable_scope('entry_flow'):
+                entry_stages = entry.pop('num_stages', 0)
+                entry_filters = entry.pop('filters')
+                entry_args = {**kwargs, **entry}
+                for i in range(entry_stages):
+                    x = cls.block(x, filters=entry_filters[i],
+                                  name='block-'+str(i), **entry_args)
+                print('DONE ENTRY')
+
+            # Entry flow: downsample the inputs
+            with tf.variable_scope('middle_flow'):
+                middle_stages = middle.pop('num_stages', 0)
+                middle_filters = middle.pop('filters')
+                middle_args = {**kwargs, **middle}
+                for i in range(middle_stages):
+                    x = cls.block(x, filters=middle_filters[i],
+                                  name='block-'+str(i), **middle_args)
+                print('DONE MIDDLE')
+
+            # Entry flow: downsample the inputs
+            with tf.variable_scope('exit_flow'):
+                exit_stages = exit.pop('num_stages', 0)
+                exit_filters = exit.pop('filters')
+                exit_args = {**kwargs, **exit}
+                for i in range(exit_stages):
+                    x = cls.block(x, filters=exit_filters[i],
+                                  name='block-'+str(i), **exit_args)
+                print('DONE EXIT')
+        return x
+
+
+
+    @classmethod
+    def block(cls, inputs, filters, combine_type='sum', name='block', **kwargs):
         """ Basic building block of the architecture.
         For details see figure 5 in the article.
 
@@ -57,7 +104,7 @@ class Xception(TFModel):
 
     @classmethod
     def separable_block(cls, inputs, filters, kernel_size=3, strides=1, rate=1,
-                        depth_activation=False, name=None, **kwargs):
+                        depth_activation=False, name='separable_block', **kwargs):
         """ Separable convolution, followed by pointwise convolution with batch-normalization in-between. """
         layout = 'nacna' if depth_activation else 'ncn'
         data_format = kwargs.get('data_format')
@@ -70,7 +117,7 @@ class Xception(TFModel):
         return x
 
     @classmethod
-    def _depthwise_conv(cls, inputs, depth_multiplier=1, name=None, **kwargs):
+    def _depthwise_conv(cls, inputs, depth_multiplier=1, name='depthwise_conv', **kwargs):
         data_format = kwargs.get('data_format')
 
         # Parse shapes
@@ -98,11 +145,19 @@ class Xception(TFModel):
         return depthwise_conv
 
 
+
+class XceptionS(Xception):
     @classmethod
-    def body(cls, inputs, name='body', **kwargs):
-        pass
+    def default_config(cls):
+        config = super().default_config()
+        config['body/entry'] = dict(num_stages=2,
+                                    filters=[[6]*3,
+                                             [12]*3,])
+        config['body/middle'] = dict(num_stages=2,
+                                     filters=[[12]*3]*2)
+        config['body/exit'] = dict(num_stages=2,
+                                   filters=[[12]*3,
+                                            [15]*3,])
+        return config
 
 
-    @classmethod
-    def head(cls, inputs, targets, name='head', **kwargs):
-        pass

--- a/batchflow/models/tf/xception.py
+++ b/batchflow/models/tf/xception.py
@@ -141,7 +141,7 @@ class Xception(TFModel):
         filters = cls.num_channels(inputs, data_format)
         depthwise_conv = tf.keras.layers.SeparableConv2D(filters=filters,
                                                          depth_multiplier=depth_multiplier,
-                                                         name='dwc', **kwargs)(inputs)
+                                                         name=name, **kwargs)(inputs)
         return depthwise_conv
 
 

--- a/batchflow/tests/encoder_decoder_test.py
+++ b/batchflow/tests/encoder_decoder_test.py
@@ -7,7 +7,7 @@ Later every combination of encoder, embedding, decoder is combined into one mode
 import pytest
 
 from batchflow.models.tf import EncoderDecoder, VariationalAutoEncoder
-from batchflow.models.tf import ResNet, MobileNet, DenseNet
+from batchflow.models.tf import ResNet, MobileNet, DenseNet, Inception_v4
 
 
 
@@ -28,6 +28,7 @@ ENCODERS = [
 EMBEDDINGS = [
     {},
     {'base': MobileNet.block, 'width_factor': 2},
+    {'base': Inception_v4.inception_c_block, 'filters': [1, 1, 1, 1]}
 ]
 
 


### PR DESCRIPTION
This PR proposes following additions:

1. Change `ASPP` module in order to make it compatible with dynamic shapes. Note that building model with dynamic `ASPP` is slower, but there is no difference at train time.
2. Add [`Xception`](https://arxiv.org/pdf/1610.02357.pdf) model architecture: authors make case for heavy usage of `depthwise_conv`-`batchnorm`-`pointwise_conv` blocks. Note that modifications, pointed out in [this](http://presentations.cocodataset.org/COCO17-Detect-MSRA.pdf) paper, are applied, as well as modifications from this [implementation.](https://github.com/tensorflow/models/blob/58a3de6c68639c3eac95f7c84089f320d32a85bb/research/deeplab/core/xception.py)
3. Add [`DeepLab`](https://arxiv.org/pdf/1802.02611.pdf) model architecture: this one uses `Xception` as its backbone, followed by `ASPP` module and simple yet effective decoder. Note that only v3+ version is implemented: previous ones are either too heavy (due to CRF usage) or less effective (due to lack of decoder). Currently `Xception` blocks are used by default; it is easy to swap them with, for example, `MobileNet v2` inverted residual blocks, and I am in search for better syntax for doing so.