### PR TITLE
add missing  padding arguments to class construcrots for dowmsample b…

### DIFF
--- a/batchflow/models/torch/base.py
+++ b/batchflow/models/torch/base.py
@@ -315,14 +315,15 @@ class TorchModel(BaseModel):
 
     def _get_device(self):
         device = self.config.get('device')
-        if device is torch.device or device is None:
+        if isinstance(device, torch.device) or device is None:
             _device = device
         elif isinstance(device, str):
             _device = device.split(':')
             unit, index = _device if len(_device) > 1 else (device, '0')
-            if unit.lower() in ['gpu', 'cpu']:
-                unit = 'cuda' if unit.lower() == 'gpu' else 'cpu'
-                _device = torch.device(unit, int(index))
+            if unit.lower() == 'gpu':
+                _device = torch.device('cuda', int(index))
+            elif unit.lower() == 'cpu':
+                _device = torch.device('cpu')
             else:
                 raise ValueError('Unknown device type: ', device)
         else:

--- a/batchflow/models/torch/layers/core.py
+++ b/batchflow/models/torch/layers/core.py
@@ -341,7 +341,7 @@ class _Pool(nn.Module):
 
             self.pool = _fn[get_num_dims(inputs)](**kwargs)
         else:
-            self.pool = _fn(inputs=inputs, **kwargs)
+            self.pool = _fn(inputs=inputs, padding=padding, **kwargs)
 
     def forward(self, x):
         if self.padding:
@@ -358,7 +358,7 @@ MAXPOOL = {
 class MaxPool(_Pool):
     """ Multi-dimensional max pooling layer """
     def __init__(self, padding='same', **kwargs):
-        super().__init__(_fn=MAXPOOL, **kwargs)
+        super().__init__(_fn=MAXPOOL, padding=padding, **kwargs)
 
 AVGPOOL = {
     1: nn.AvgPool1d,
@@ -369,7 +369,7 @@ AVGPOOL = {
 class AvgPool(_Pool):
     """ Multi-dimensional average pooling layer """
     def __init__(self, padding='same', **kwargs):
-        super().__init__(_fn=AVGPOOL, **kwargs)
+        super().__init__(_fn=AVGPOOL, padding=padding, **kwargs)
 
 
 class Pool(_Pool):


### PR DESCRIPTION
1. In torch models padding parameter for downsample block does not  go down from models config to actual action.
Whenever we call `Pool` layer, `_Pool` class constructor executed twice. First time directly from `Pool`, second time - from one of the `MaxPool / AvgPool` classes.    
During the first execution `padding` pops from `kwargs` therefore the second time `_Pool` constructor is always being called with default padding value.

2. `_get_device()` method:
    1.  The condition ` device is torch.device` is  `False` in case `device = torch.device('cuda')`. I believe it was supposed to return `True`?
    2.  `torch.device('cpu', index)` : unlike CUDA the only available index for CPU device is 0. You can verify it. Its not clear from the documentation whats the difference between `torch.device('cpu')` and `torch.device('cpu', 0)`. However, it becomes critical when we come down to  `load` method, in particular this piece of code:

        `if device: checkpoint = torch.load(path, map_location=device)`

    Works well if `map_location = torch.device('cpu')` and falls with error if  `map_location = torch.device('cpu', 0)`. I suggest to not include index for CPU devices at all.