### PR TITLE
Fix run

### DIFF
--- a/batchflow/base.py
+++ b/batchflow/base.py
@@ -167,16 +167,17 @@ class Baseset:
     def gen_batch(self, batch_size, shuffle=False, n_iters=None, n_epochs=None, drop_last=False,
                   bar=False, bar_desc=None, *args, **kwargs):
         """ Generate batches """
-        iter_params = kwargs.pop('iter_params', None)
+        global_iter_params = kwargs.pop('global_iter_params', None)
         for ix_batch in self.index.gen_batch(batch_size, shuffle, n_iters, n_epochs, drop_last,
-                                             bar, bar_desc, iter_params):
+                                             bar, bar_desc, global_iter_params):
             batch = self.create_batch(ix_batch, *args, **kwargs)
             yield batch
 
     def next_batch(self, batch_size, shuffle=False, n_iters=None, n_epochs=None, drop_last=False,
-                   iter_params=None, *args, **kwargs):
+                   *args, **kwargs):
         """ Return a batch """
-        batch_index = self.index.next_batch(batch_size, shuffle, n_iters, n_epochs, drop_last, iter_params)
+        global_iter_params = kwargs.pop('global_iter_params', None)
+        batch_index = self.index.next_batch(batch_size, shuffle, n_iters, n_epochs, drop_last, global_iter_params)
         batch = self.create_batch(batch_index, *args, **kwargs)
         return batch
 

--- a/batchflow/base.py
+++ b/batchflow/base.py
@@ -173,8 +173,7 @@ class Baseset:
             batch = self.create_batch(ix_batch, *args, **kwargs)
             yield batch
 
-    def next_batch(self, batch_size, shuffle=False, n_iters=None, n_epochs=None, drop_last=False,
-                   *args, **kwargs):
+    def next_batch(self, batch_size, shuffle=False, n_iters=None, n_epochs=None, drop_last=False, *args, **kwargs):
         """ Return a batch """
         global_iter_params = kwargs.pop('global_iter_params', None)
         batch_index = self.index.next_batch(batch_size, shuffle, n_iters, n_epochs, drop_last, global_iter_params)

--- a/batchflow/dsindex.py
+++ b/batchflow/dsindex.py
@@ -397,10 +397,12 @@ class DatasetIndex(Baseset):
             if n_iters is not None or drop_last and (rest_items is None or len(rest_items) < batch_size):
                 raise StopIteration("Dataset is over. No more batches left.")
             iter_params['_stop_iter'] = True
-            global_iter_params['_n_iters'] += 1
+            if global_iter_params:
+                global_iter_params['_n_iters'] += 1
             return self.create_batch(rest_items, pos=True)
 
-        global_iter_params['_n_iters'] += 1
+        if global_iter_params:
+            global_iter_params['_n_iters'] += 1
         iter_params['_start_index'] += rest_of_batch
         return self.create_batch(batch_items, pos=True)
 
@@ -487,10 +489,11 @@ class DatasetIndex(Baseset):
         else:
             total = math.ceil(len(self) * n_epochs / batch_size)
 
-        if total:
-            global_iter_params['_total'] = global_iter_params['_n_iters'] + total
-        else:
-            global_iter_params['_total'] = None
+        if global_iter_params:
+            if total:
+                global_iter_params['_total'] = global_iter_params['_n_iters'] + total
+            else:
+                global_iter_params['_total'] = None
 
         if bar:
             if callable(bar):

--- a/batchflow/named_expr.py
+++ b/batchflow/named_expr.py
@@ -628,16 +628,16 @@ class I(NamedExpression):
 
         pipeline = batch.pipeline if batch is not None else pipeline
         if 'current'.startswith(name):
-            return pipeline._iter_params['_n_iters']    # pylint:disable=protected-access
+            return pipeline._global_iter_params['_n_iters']    # pylint:disable=protected-access
 
-        total = pipeline._iter_params.get('_total')    # pylint:disable=protected-access
+        total = pipeline._global_iter_params.get('_total')    # pylint:disable=protected-access
 
         if 'maximum'.startswith(name):
             return total
         if 'ratio'.startswith(name):
             if total is None:
                 raise ValueError('Total number of iterations is not defined!')
-            ratio = pipeline._iter_params['_n_iters'] / total    # pylint:disable=protected-access
+            ratio = pipeline._global_iter_params['_n_iters'] / total    # pylint:disable=protected-access
             return ratio
 
         raise ValueError('Unknown key for named expresssion I: %s' % name)

--- a/batchflow/pipeline.py
+++ b/batchflow/pipeline.py
@@ -89,7 +89,6 @@ class Pipeline:
         self._batch_queue = None
         self._batch_generator = None
         self._rest_batch = None
-        self._iter_params = None
         self._global_iter_params = None
 
     def __enter__(self):
@@ -1269,7 +1268,6 @@ class Pipeline:
         prefetch = kwargs.pop('prefetch', 0)
         on_iter = kwargs.pop('on_iter', None)
 
-        # if kwargs.pop('global_iter_params', None) is None:
         self._global_iter_params = self._global_iter_params or {'_total': None, '_n_iters': 0}
 
         if len(self._actions) > 0 and self._actions[0]['name'] == REBATCH_ID:
@@ -1370,8 +1368,10 @@ class Pipeline:
 
         Parameters
         ----------
-        reset_pipeline : bool
+        init_vars : bool
             whether to clear all the pipeline variables
+        reset_pipeline : bool
+            whether to reset iteration counter
 
         See also
         --------


### PR DESCRIPTION
This PR:
1) reverts `iter_params` to its previous role as iteration config for index only;
2) introduces pipeline's private attribute `_global_iter_params` to track current and total number of iterations on pipeline level;
3) adds argument `reset_pipeline` to `pipeline.run` that resets `_global_iter_params` upon new run if `True`. Default is `False`;
4) fixes that little annoying thing that in case `bar` is True it never reaches total number of iterations, stopping one step before.