### PR TITLE
Encoder_decoder improvements

### DIFF
--- a/batchflow/models/tf/encoder_decoder.py
+++ b/batchflow/models/tf/encoder_decoder.py
@@ -271,7 +271,7 @@ class EncoderDecoder(TFModel):
                                 x = conv_block(x, name='downsample', **downsample_args)
                             x = base_block(x, name='block', **args)
                         else:
-                            raise ValueError('Unknown order {}, use one of {"bd", "db"}'.format(order))
+                            raise ValueError('Unknown order {}, use one of ("bd", "db")'.format(order))
                         encoder_outputs.append(x)
         return encoder_outputs
 
@@ -394,7 +394,7 @@ class EncoderDecoder(TFModel):
                         if upsample.get('layout') is not None:
                             x = cls.upsample(x, name='upsample', **upsample_args)
                     else:
-                        raise ValueError('Unknown order {}, use one of {"ub", "bu"}'.format(order))
+                        raise ValueError('Unknown order {}, use one of ("ub", "bu")'.format(order))
 
                     # Combine result with the stored encoding of the ~same shape
                     if skip and (i < len(inputs)-2):

--- a/batchflow/models/tf/encoder_decoder.py
+++ b/batchflow/models/tf/encoder_decoder.py
@@ -244,7 +244,7 @@ class EncoderDecoder(TFModel):
         list of tf.Tensors
         """
         base_class = kwargs.pop('base')
-        steps, downsample, block_args, order = cls.pop(['num_stages', 'downsample', 'blocks', 'order'], kwargs)
+        steps, order, downsample, block_args = cls.pop(['num_stages', 'order', 'downsample', 'blocks'], kwargs)
         order = ''.join([item[0] for item in order])
 
         if base_class is not None:
@@ -271,7 +271,7 @@ class EncoderDecoder(TFModel):
                                 x = conv_block(x, name='downsample', **downsample_args)
                             x = base_block(x, name='block', **args)
                         else:
-                            raise ValueError('Unknown order, use one of {"bd", "db"}')
+                            raise ValueError('Unknown order {}, use one of {"bd", "db"}'.format(order))
                         encoder_outputs.append(x)
         return encoder_outputs
 
@@ -358,7 +358,7 @@ class EncoderDecoder(TFModel):
         """
         steps = kwargs.pop('num_stages') or len(inputs)-2
         factor = kwargs.pop('factor') or [2]*steps
-        skip, upsample, block_args, order = cls.pop(['skip', 'upsample', 'blocks', 'order'], kwargs)
+        skip, order, upsample, block_args = cls.pop(['skip', 'order', 'upsample', 'blocks'], kwargs)
         order = ''.join([item[0] for item in order])
         base_block = block_args.get('base')
 
@@ -394,7 +394,7 @@ class EncoderDecoder(TFModel):
                         if upsample.get('layout') is not None:
                             x = cls.upsample(x, name='upsample', **upsample_args)
                     else:
-                        raise ValueError('Unknown order, use one of {"ub", "bu"}')
+                        raise ValueError('Unknown order {}, use one of {"ub", "bu"}'.format(order))
 
                     # Combine result with the stored encoding of the ~same shape
                     if skip and (i < len(inputs)-2):

--- a/batchflow/models/tf/layers/layer.py
+++ b/batchflow/models/tf/layers/layer.py
@@ -15,11 +15,11 @@ def add_as_function(cls):
 
     def func(inputs, *args, **kwargs):
         # We also want to use `training` or `is_training` indicators as arguments for call
-        call_args = []
+        call_args = [inputs]
         training = kwargs.get('training') or kwargs.get('is_training')
-        if training is not None:
-            call_args = [training]
-        return cls(*args, **kwargs)(inputs, *call_args)
+        if (training is not None) and (len(inspect.getfullargspec(cls.__call__)[0]) == 3):
+            call_args.append(training)
+        return cls(*args, **kwargs)(*call_args)
 
     module = inspect.getmodule(inspect.stack()[1][0])
     setattr(module, func_name, func)

--- a/batchflow/models/tf/layers/layer.py
+++ b/batchflow/models/tf/layers/layer.py
@@ -17,7 +17,7 @@ def add_as_function(cls):
         # We also want to use `training` or `is_training` indicators as arguments for call
         call_args = [inputs]
         training = kwargs.get('training') or kwargs.get('is_training')
-        if (training is not None) and (len(inspect.getfullargspec(cls.__call__)[0]) == 3):
+        if (training is not None) and (len(inspect.getfullargspec(cls.__call__)[0]) > 2):
             call_args.append(training)
         return cls(*args, **kwargs)(*call_args)
 


### PR DESCRIPTION
This PR proposes to:

- make order of operations configurable in both `encoder` and `decoder`: you can either process tensor via chosen `block` and then change its spatial resolution with `downsampling`/`upsampling`, or vice versa

- `skip` parameter of `decoder/blocks` can now be a dictionary of parameters, that are passed to `combine` function

- now `add_as_function` decorator is smart enough to pass `training` tensor only when needed