### PR TITLE
New order

### DIFF
--- a/batchflow/models/tf/base.py
+++ b/batchflow/models/tf/base.py
@@ -333,10 +333,7 @@ class TFModel(BaseModel):
                                               data_format=self.full_config.get('common/data_format', 'channels_last'))
                             config = self.build_config()
 
-                            self._full_config = config
                             self._build(config)
-
-                self.microbatch = config.get('microbatch')
 
                 if self.session is None:
                     self.create_session(config)
@@ -635,6 +632,8 @@ class TFModel(BaseModel):
         return tensor
 
     def _make_train_steps(self, config, init=True):
+        self.microbatch = config.get('microbatch')
+
         # Wrap parameters from config root as `train_steps`
         if config.get('train_steps') is None:
             config.update({'train_steps': {'': {key: config.get(key) for key in

--- a/batchflow/models/tf/base.py
+++ b/batchflow/models/tf/base.py
@@ -1035,7 +1035,7 @@ class TFModel(BaseModel):
 
         return output
 
-    def train(self, fetches=None, feed_dict=None, use_lock=False, train_mode='', microbatch=None, **kwargs):
+    def train(self, fetches=None, feed_dict=None, use_lock=True, train_mode='', microbatch=None, **kwargs):
         """ Train the model with the data provided
 
         Parameters


### PR DESCRIPTION
This PR proposes to split creating `default_config`, `making_inputs` and `building_config` into separate things, that are called directly in `TFModel.build`. 

It also changes default for `use_lock` parameter of `train` method to be `True`.