### PR TITLE
Fix docs

### DIFF
--- a/batchflow/batch_image.py
+++ b/batchflow/batch_image.py
@@ -546,24 +546,7 @@ class ImagesBatch(BaseImagesBatch):
         Parameters
         ----------
         origin : sequence, str
-            Location of the cropping box. Can be one of:
-                - 'center' - place the center of the input image on the center of the background and crop
-                  the input image accordingly.
-                - 'top_left' - place the upper-left corner of the input image on the upper-left of the background
-                  and crop the input image accordingly.
-                - 'top_right' - crop an image such that upper-right corners of
-                  an image and the cropping box coincide
-                - 'bottom_left' - crop an image such that lower-left corners of
-                  an image and the cropping box coincide
-                - 'bottom_right' - crop an image such that lower-right corners of
-                  an image and the cropping box coincide
-                - 'random' - place the upper-left corner of the input image on the randomly sampled position
-                  in the background. Position is sampled uniformly such that there is no need for cropping.
-                - array_like - sequence of ints or sequence of floats in [0, 1) interval;
-                  place the upper-left corner of the input image on the given position in the background.
-                  If `origin` is a sequence of floats in [0, 1), it defines a relative position
-                  of the origin in a valid region of image.
-
+            Location of the cropping box. See :meth:`.ImagesBatch._calc_origin` for details.
         shape : sequence
             crop size in the form of (rows, columns)
         crop_boundaries : bool
@@ -602,24 +585,7 @@ class ImagesBatch(BaseImagesBatch):
         background : PIL.Image, np.ndarray of np.uint8
             Blank background to put image on.
         origin : sequence, str
-            Location of the cropping box. Can be one of:
-                - 'center' - place the center of the input image on the center of the background and crop
-                  the input image accordingly.
-                - 'top_left' - place the upper-left corner of the input image on the upper-left of the background
-                  and crop the input image accordingly.
-                - 'top_right' - crop an image such that upper-right corners of
-                  an image and the cropping box coincide
-                - 'bottom_left' - crop an image such that lower-left corners of
-                  an image and the cropping box coincide
-                - 'bottom_right' - crop an image such that lower-right corners of
-                  an image and the cropping box coincide
-                - 'random' - place the upper-left corner of the input image on the randomly sampled position
-                  in the background. Position is sampled uniformly such that there is no need for cropping.
-                - array_like - sequence of ints or sequence of floats in [0, 1) interval;
-                  place the upper-left corner of the input image on the given position in the background.
-                  If `origin` is a sequence of floats in [0, 1), it defines a relative position
-                  of the origin in a valid region of image.
-
+            Location of the cropping box. See :meth:`.ImagesBatch._calc_origin` for details.
         mask : None, PIL.Image, np.ndarray of np.uint8
             mask passed to PIL.Image.paste
 
@@ -1069,23 +1035,7 @@ class ImagesBatch(BaseImagesBatch):
         Parameters
         ----------
         origin : sequence, str
-            Location of the cropping box. Can be one of:
-                - 'top_left' - crop an image such that upper-left corners of
-                  an image and the filled box coincide.
-                - 'top_right' - crop an image such that upper-right corners of
-                  an image and the cropping box coincide
-                - 'bottom_left' - crop an image such that lower-left corners of
-                  an image and the cropping box coincide
-                - 'bottom_right' - crop an image such that lower-right corners of
-                  an image and the cropping box coincide
-                - 'center' - crop an image such that centers of
-                  an image and the filled box coincide.
-                - 'random' - place the upper-left corner of the filled box at a random position.
-                - array_like - sequence of ints or sequence of floats in [0, 1) interval;
-                  place the upper-left corner of the input image on the given position in the background.
-                  If `origin` is a sequence of floats in [0, 1), it defines a relative position
-                  of the origin in a valid region of image.
-
+            Location of the cropping box. See :meth:`.ImagesBatch._calc_origin` for details.
         shape : sequence, int
             Shape of a filled box. Can be one of:
                 - sequence - crop size in the form of (rows, columns)
@@ -1227,7 +1177,7 @@ class ImagesBatch(BaseImagesBatch):
         """ Deformation of images as described by Simard, Steinkraus and Platt, `Best Practices for Convolutional
         Neural Networks applied to Visual Document Analysis <http://cognitivemedium.com/assets/rmnist/Simard.pdf>_`.
 
-        Code slightly differs with `<https://gist.github.com/chsasank/4d8f68caf01f041a6453e67fb30f8f5a>`_.
+        Code slightly differs from `<https://gist.github.com/chsasank/4d8f68caf01f041a6453e67fb30f8f5a>`_.
 
         Parameters
         ----------

--- a/batchflow/batch_image.py
+++ b/batchflow/batch_image.py
@@ -708,7 +708,8 @@ class ImagesBatch(BaseImagesBatch):
     def _transform_(self, image, *args, **kwargs):
         """ Calls ``image.transform(*args, **kwargs)``
 
-        For more information see `<http://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.transform>_`.
+        For more information see
+        `<http://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.transform>_`.
 
         Parameters
         ----------

--- a/batchflow/batch_image.py
+++ b/batchflow/batch_image.py
@@ -706,7 +706,7 @@ class ImagesBatch(BaseImagesBatch):
         return image.filter(getattr(PIL.ImageFilter, mode)(*args, **kwargs))
 
     def _transform_(self, image, *args, **kwargs):
-        """ Calls ``image.transform(*args, **kwargs)``
+        """ Calls ``image.transform(*args, **kwargs)``.
 
         For more information see
         `<http://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.transform>_`.
@@ -777,9 +777,9 @@ class ImagesBatch(BaseImagesBatch):
         return image
 
     def _pad_(self, image, *args, **kwargs):
-        """ Calls PIL.ImageOps.expand.
+        """ Calls ``PIL.ImageOps.expand``.
 
-        For more details see http://pillow.readthedocs.io/en/stable/reference/ImageOps.html#PIL.ImageOps.expand
+        For more details see `<http://pillow.readthedocs.io/en/stable/reference/ImageOps.html#PIL.ImageOps.expand>`_.
 
         Parameters
         ----------
@@ -1028,7 +1028,7 @@ class ImagesBatch(BaseImagesBatch):
         return image.astype(dtype)
 
     def _pil_convert_(self, image, mode="L"):
-        """ Convert image. Actually calls image.convert(mode)
+        """ Convert image. Actually calls ``image.convert(mode)``.
 
         Parameters
         ----------
@@ -1227,7 +1227,7 @@ class ImagesBatch(BaseImagesBatch):
         """ Deformation of images as described by Simard, Steinkraus and Platt, `Best Practices for Convolutional
         Neural Networks applied to Visual Document Analysis <http://cognitivemedium.com/assets/rmnist/Simard.pdf>_`.
 
-        Code slightly differs with https://gist.github.com/chsasank/4d8f68caf01f041a6453e67fb30f8f5a
+        Code slightly differs with `<https://gist.github.com/chsasank/4d8f68caf01f041a6453e67fb30f8f5a>`_.
 
         Parameters
         ----------

--- a/batchflow/models/base.py
+++ b/batchflow/models/base.py
@@ -58,6 +58,16 @@ class BaseModel:
         return Config().put(variable, value, config)
 
     def _make_inputs(self, names=None, config=None):
+        """ Make model input data using config
+
+        Parameters
+        ----------
+        names : a sequence of str - names for input variables
+
+        Returns
+        -------
+        None or dict - where key is a variable name and a value is a corresponding variable after configuration
+        """
         _ = names, config
         return None
 

--- a/batchflow/models/base.py
+++ b/batchflow/models/base.py
@@ -58,16 +58,6 @@ class BaseModel:
         return Config().put(variable, value, config)
 
     def _make_inputs(self, names=None, config=None):
-        """ Make model input data using config
-
-        Parameters
-        ----------
-        names : a sequence of str - names for input variables
-
-        Returns
-        -------
-        None or dict - where key is a variable name and a value is a corresponding variable after configuration
-        """
         _ = names, config
         return None
 

--- a/batchflow/models/tf/base.py
+++ b/batchflow/models/tf/base.py
@@ -92,8 +92,8 @@ class TFModel(BaseModel):
         Loss function, might be defined in multiple formats.
 
         If str, then short ``name``.
-        If tuple, then ``(name, args)``.
-        If dict, then ``{'name': name, **args}``.
+        If tuple, then ``(name, *args)``.
+        If dict, then ``{'name': name, **kwargs}``.
 
         Name must be one of:
             - short name (e.g. ``'mse'``, ``'ce'``, ``'l1'``, ``'cos'``, ``'hinge'``,
@@ -117,15 +117,15 @@ class TFModel(BaseModel):
         - ``{'loss': (tf.losses.huber_loss, {'reduction': tf.losses.Reduction.MEAN})}``
         - ``{'loss': {'name': 'dice', 'predictions': 'body_output', 'targets': 'body_targets'}``
         - ``{'loss': external_loss_fn_with_add_loss_inside}``
-        - ``{'loss': external_loss_fn_without_add_loss, 'add_loss': True}``
-        - ``{'loss': external_loss_fn_to_collection, 'add_loss': True, 'loss_collection': tf.GraphKeys.LOSSES}``
+        - ``{'loss': {'name': external_loss_fn_without_add_loss, 'add_loss': True}}``
+        - ``{'loss': {'name': external_loss_fn, 'add_loss': True, 'loss_collection': tf.GraphKeys.LOSSES}}``
 
     optimizer : str, tuple, dict
         Optimizer, might be defined in multiple formats.
 
         If str, then short ``name``.
-        If tuple, then ``(name, args)``.
-        If dict, then ``{'name': name, **args}``.
+        If tuple, then ``(name, *args)``.
+        If dict, then ``{'name': name, **kwargs}``.
 
         Name must be one of:
             - short name (e.g. ``'Adam'``, ``'Adagrad'``, any optimizer from
@@ -146,8 +146,8 @@ class TFModel(BaseModel):
         Learning rate decay algorithm, might be defined in multiple formats.
 
         If str, then short ``name``.
-        If tuple, then ``(name, args)``.
-        If dict, then ``{'name': name, **args}``.
+        If tuple, then ``(name, *args)``.
+        If dict, then ``{'name': name, **kwargs}``.
 
         Name must be one of:
             - short name (e.g. ``'exp'``, ``'invtime'``, ``'naturalexp'``, ``'const'``, ``'poly'``, ``'cyclic'``)

--- a/batchflow/models/tf/base.py
+++ b/batchflow/models/tf/base.py
@@ -50,13 +50,13 @@ class TFModel(BaseModel):
     Parameters
     ----------
     inputs : dict
-        Mapping from placeholder names (e.g. `images`, `labels`, `masks`) to arguments of its initialization.
+        Mapping from placeholder names (e.g. ``images``, ``labels``, ``masks``) to arguments of its initialization.
         Allows to create placeholders of needed format (shape, dtype, data format) with specified name
         and apply some typical transformations (like one-hot-encoding), if needed.
 
         If value is a string, then it must point to another key from the input-dict, effectively making an alias.
-        By default, `targets` is aliased to `labels` or `masks`, if present.
-        If value is a tuple, then it must contain all of the arguments below in the same order. `None` is reserved
+        By default, ``targets`` is aliased to ``labels`` or ``masks``, if present.
+        If value is a tuple, then it must contain all of the arguments below in the same order. ``None`` is reserved
         for using default value.
         If value is a dictionary, then it can omit some of the parameters (default values will be at use).
 
@@ -71,7 +71,7 @@ class TFModel(BaseModel):
                 If array-like, then labels of classes (can be strings or anything else).
                 If None, then tensor has no classes. Default is None.
 
-            data_format : str {'channels_first', 'channels_last', 'f', 'l'}
+            data_format : {'channels_first', 'channels_last', 'f', 'l'}
                 The ordering of the dimensions in the inputs. Can be shortened to ``df`` for brevity.
                 Default is 'channels_last'.
 
@@ -96,9 +96,10 @@ class TFModel(BaseModel):
         If dict, then ``{'name': name, **args}``.
 
         Name must be one of:
-            - short name (e.g. `'mse'`, `'ce'`, `'l1'`, `'cos'`, `'hinge'`, `'huber'`, `'logloss'`, `'dice'`)
+            - short name (e.g. ``'mse'``, ``'ce'``, ``'l1'``, ``'cos'``, ``'hinge'``,
+              ``'huber'``, ``'logloss'``, ``'dice'``)
             - a function name from `tf.losses <https://www.tensorflow.org/api_docs/python/tf/losses>`_
-              (e.g. `'absolute_difference'` or `'sparse_softmax_cross_entropy'`)
+              (e.g. ``'absolute_difference'`` or ``'sparse_softmax_cross_entropy'``)
             - callable
 
         It is possible to compute loss not only with network output and ground truth, but with
@@ -127,10 +128,10 @@ class TFModel(BaseModel):
         If dict, then ``{'name': name, **args}``.
 
         Name must be one of:
-            - short name (e.g. `'Adam'`, `'Adagrad'`, any optimizer from
-              `tf.train <https://www.tensorflow.org/api_docs/python/tf/train>`_ with or without a word `Optimizer`)
+            - short name (e.g. ``'Adam'``, ``'Adagrad'``, any optimizer from
+              `tf.train <https://www.tensorflow.org/api_docs/python/tf/train>`_ with or without word `Optimizer`)
             - a function name from `tf.train <https://www.tensorflow.org/api_docs/python/tf/train>`_
-              (e.g. 'FtlrOptimizer')
+              (e.g. ``'FtlrOptimizer'``)
             - callable
 
         Examples:
@@ -149,9 +150,9 @@ class TFModel(BaseModel):
         If dict, then ``{'name': name, **args}``.
 
         Name must be one of:
-            - short name (e.g. `'exp'`, `'invtime'`, `'naturalexp'`, `'const'`, `'poly'`)
+            - short name (e.g. ``'exp'``, ``'invtime'``, ``'naturalexp'``, ``'const'``, ``'poly'``, ``'cyclic'``)
             - a function name from `tf.train <https://www.tensorflow.org/api_docs/python/tf/train>`_
-              (e.g. 'exponential_decay')
+              (e.g. ``'exponential_decay'``)
             - callable
 
         Examples:
@@ -1506,8 +1507,8 @@ class TFModel(BaseModel):
 
         Notes
         -----
-        In order to use custom class as encoder, `body` must create `group-i/output` tensors.
-        An example of this can be seen in :class:`Xception`.
+        In order to use custom class as encoder, body of the network must create ``group-i/output`` tensors.
+        An example of this can be seen in :class:`~.Xception`.
         """
         config = cls.fill_params('body', **kwargs)
         order = config.get('order')
@@ -1706,7 +1707,7 @@ class TFModel(BaseModel):
 
     @classmethod
     def default_config(cls):
-        """ Define model defaultsю
+        """ Define model defaults.
 
         You need to override this method if you expect your model or its blocks to serve as a base for other models
         (e.g. VGG for FCN, ResNet for LinkNet, etc).

--- a/batchflow/models/tf/encoder_decoder.py
+++ b/batchflow/models/tf/encoder_decoder.py
@@ -66,7 +66,7 @@ class EncoderDecoder(TFModel):
                 If bool, then whether to combine upsampled tensor with stored pre-downsample encoding by
                 using `combine_op`, that can be specified for each of blocks separately.
                 If dict, then parameters for combining upsampled tensor with stored pre-downsample encoding,
-                see :class:`~.layers.Combine`.
+                see :class:`~.tf.layers.Combine`.
 
             order : str, sequence of str
                 Determines order of applying layers.
@@ -84,8 +84,8 @@ class EncoderDecoder(TFModel):
                 base : callable
                     Tensor processing function. Default is :func:`~.layers.conv_block`.
                 combine_op : str, dict
-                    If str, then operation for combining tensors, see :class:`~.layers.Combine`.
-                    If dict, then parameters for combining tensors, see :class:`~.layers.Combine`.
+                    If str, then operation for combining tensors, see :class:`~.tf.layers.Combine`.
+                    If dict, then parameters for combining tensors, see :class:`~.tf.layers.Combine`.
                 other args : dict
                     Parameters for the base block.
 
@@ -340,7 +340,7 @@ class EncoderDecoder(TFModel):
             If bool, then whether to combine upsampled tensor with stored pre-downsample encoding by using `combine_op`,
             that can be specified for each of blocks separately..
             If dict, then parameters for combining upsampled tensor with stored pre-downsample encoding,
-            see :class:`~.layers.Combine`.
+            see :class:`~.tf.layers.Combine`.
 
         order : str, sequence of str
             Determines order of applying layers.
@@ -357,8 +357,8 @@ class EncoderDecoder(TFModel):
             base : callable
                 Tensor processing function. Default is :func:`~.layers.conv_block`.
             combine_op : str, dict
-                If str, then operation for combining tensors, see :class:`~.layers.Combine`.
-                If dict, then parameters for combining tensors, see :class:`~.layers.Combine`.
+                If str, then operation for combining tensors, see :class:`~.tf.layers.Combine`.
+                If dict, then parameters for combining tensors, see :class:`~.tf.layers.Combine`.
             other args : dict
                 Parameters for the base block.
 

--- a/batchflow/models/tf/inception_v3.py
+++ b/batchflow/models/tf/inception_v3.py
@@ -25,7 +25,7 @@ class Inception_v3(Inception):
     -----
     Since the article misses some important details (e.g. the number of filters in all convolutions),
     this class is based on `Google's implementation
-    <https://github.com/tensorflow/models/blob/master/research/slim/nets/inception_v3.py>`_
+    <https://github.com/tensorflow/models/blob/master/research/slim/nets/inception_v3.py>`__.
 
     **Configuration**
 

--- a/batchflow/models/tf/layers/layer.py
+++ b/batchflow/models/tf/layers/layer.py
@@ -20,6 +20,7 @@ def add_as_function(cls):
         if (training is not None) and (len(inspect.getfullargspec(cls.__call__)[0]) > 2):
             call_args.append(training)
         return cls(*args, **kwargs)(*call_args)
+    func.__doc__ = cls.__doc__
 
     module = inspect.getmodule(inspect.stack()[1][0])
     setattr(module, func_name, func)

--- a/batchflow/models/tf/layers/pooling.py
+++ b/batchflow/models/tf/layers/pooling.py
@@ -27,9 +27,9 @@ class MaxPooling(Layer):
 
     See also
     --------
-    `tf.layers.max_pooling1d <https://www.tensorflow.org/api_docs/python/keras/layers/MaxPool1D>`_,
-    `tf.layers.max_pooling2d <https://www.tensorflow.org/api_docs/python/keras/layers/MaxPool2D>`_,
-    `tf.layers.max_pooling3d <https://www.tensorflow.org/api_docs/python/keras/layers/MaxPool3D>`_
+    `tf.layers.max_pooling1d <https://www.tensorflow.org/api_docs/python/keras/layers/MaxPool1D>`__,
+    `tf.layers.max_pooling2d <https://www.tensorflow.org/api_docs/python/keras/layers/MaxPool2D>`__,
+    `tf.layers.max_pooling3d <https://www.tensorflow.org/api_docs/python/keras/layers/MaxPool3D>`__.
     """
     LAYERS = {
         1: K.MaxPool1D,
@@ -69,9 +69,9 @@ class AveragePooling(Layer):
 
     See also
     --------
-    `tf.layers.max_pooling1d <https://www.tensorflow.org/api_docs/python/keras/layers/AveragePooling1D>`_,
-    `tf.layers.max_pooling2d <https://www.tensorflow.org/api_docs/python/keras/layers/AveragePooling2D>`_,
-    `tf.layers.max_pooling3d <https://www.tensorflow.org/api_docs/python/keras/layers/AveragePooling3D>`_
+    `tf.layers.max_pooling1d <https://www.tensorflow.org/api_docs/python/keras/layers/AveragePooling1D>`__,
+    `tf.layers.max_pooling2d <https://www.tensorflow.org/api_docs/python/keras/layers/AveragePooling2D>`__,
+    `tf.layers.max_pooling3d <https://www.tensorflow.org/api_docs/python/keras/layers/AveragePooling3D>`__.
     """
     LAYERS = {
         1: K.AveragePooling1D,

--- a/batchflow/models/tf/mobilenet.py
+++ b/batchflow/models/tf/mobilenet.py
@@ -58,25 +58,19 @@ _V3_SMALL_DEFAULT_BODY = [
 
 
 class MobileNet(TFModel):
-    """ MobileNet
+    """ MobileNet.
 
-    **Configuration**
-
-    inputs : dict
-        dict with 'images' and 'labels' (see :meth:`~.TFModel._make_inputs`)
-
-    initial_block : dict
-        parameters for the initial block (default is 'cna', 32, 3, strides=2)
-
+    Parameters
+    ----------
     body : dict
         strides : list of int
-            strides in separable convolutions
+            Strides in separable convolutions.
 
         double_filters : list of bool
-            if True, number of filters in 1x1 covolution will be doubled
+            If True, then number of filters in 1x1 covolution will be doubled.
 
         width_factor : float
-            multiplier for the number of channels (default=1)
+            Multiplier for the number of channels (default=1).
     """
     @classmethod
     def default_config(cls):
@@ -149,40 +143,39 @@ class MobileNet(TFModel):
 
 
 class MobileNet_v2(TFModel):
-    """ Base class for MobileNets after v2
+    """ Base class for MobileNets after v2.
 
-    **Configuration**
-
-    inputs : dict
-        dict with 'images' and 'labels' (see :meth:`.TFModel._make_inputs`)
-
-    initial_block : dict
-        parameters for the initial block (default is 'cna', 32, 3, strides=2)
-
+    Parameters
+    ----------
     body : dict
-        layout : list of dict each consisting of parameters:
+        layout : list of dict
+            Defines body structure. Each dict must contain following parameters.
+
             repeats : int
-                number of repeats of the block
+                Number of repeats of the block.
             filters : int
-                number of output filters in the block
+                Number of output filters in the block.
             expansion_factor : int
-                multiplier for the number of filters in internal convolutions
+                Multiplier for the number of filters in internal convolutions.
             strides : int
-                stride for 3x3 convolution
+                Stride for 3x3 convolution.
             kernel_size : int
-                kernel size for depthwise convolution
+                Kernel size for depthwise convolution.
             activation : callable, optional
+                Activation function.
             se_block : bool or dict
-                whether to include squeeze and excitation block
-                If dict, it must contain :meth:`~TFModel.se_block` params
+                Whether to include squeeze and excitation block.
+                If dict, then parameters for :meth:`~TFModel.se_block`.
             residual : bool
-                whether to make a residual connection
+                Whether to make a residual connection.
+
         width_factor : float
-            multiplier for the number of channels (default=1)
+            Multiplier for the number of channels (default=1).
 
     head : dict
         se_block : dict, optional
-            None or a dict with :meth:`~TFModel.se_block` params
+            Whether to include squeeze and excitation block.
+            If dict, then parameters for :meth:`~TFModel.se_block`.
     """
     @classmethod
     def default_config(cls):
@@ -310,7 +303,7 @@ class MobileNet_v2(TFModel):
 
 
 class MobileNet_v3(MobileNet_v2):
-    """ MobileNet version 3 large """
+    """ MobileNet version 3 large. """
     @classmethod
     def default_config(cls):
         config = TFModel.default_config()
@@ -324,7 +317,7 @@ class MobileNet_v3(MobileNet_v2):
 
 
 class MobileNet_v3_small(MobileNet_v3):
-    """ MobileNet version 3 small """
+    """ MobileNet version 3 small. """
     @classmethod
     def default_config(cls):
         config = TFModel.default_config()

--- a/batchflow/models/tf/nn/train.py
+++ b/batchflow/models/tf/nn/train.py
@@ -35,52 +35,43 @@ def cyclic_learning_rate(learning_rate, global_step, max_lr, step_size=10,
 
     Notes
     -----
-    More detailed information about `mode`.
+    More detailed information about `mode`:
 
     If 'tri':
         Default, linearly increasing then linearly decreasing the
         learning rate at each cycle. Learning rate starting
         from (max_lr-learning_rate)/2 then decreasing to `learning_rate`.
-        Published in article [1]_.
-        It is computed as:
+        See `Leslie N. Smith, Cyclical Learning Rates for Training Neural Networks
+        <https://arxiv.org/abs/1506.01186>`_ for more information.
 
-        ```python
-        decayed_learning_rate = abs(mod((global_step + step_size / 4) / step_size, 1) - 0.5) *
-                                2 * (max_lr - learning_rate) +
-                                learning_rate
+        It is computed as::
 
-        ```
+            decayed_learning_rate = abs(mod((global_step + step_size / 4) / step_size, 1) - 0.5) *
+                                    2 * (max_lr - learning_rate) +
+                                    learning_rate
+
 
     If 'sin':
         Learning rate changes as a sine wave, starting
         from (max_lr-learning_rate)/2 then decreasing to `learning_rate`.
-        It is computed as:
 
-        ```python
-        decayed_learning_rate = (learning_rate - max_lr) / 2 *
-                                sin(pi * global_step / step_size) +
-                                (max_lr + learning_rate) / 2
+        It is computed as::
 
-        ```
+            decayed_learning_rate = (learning_rate - max_lr) / 2 *
+                                    sin(pi * global_step / step_size) +
+                                    (max_lr + learning_rate) / 2
+
 
     If 'saw':
         Learning rate linearly increasing from `learning_rate` to `max_lr`
         and then sharply drops to `learning_rate` at each cycle.
         Learning rate starting from `learning_rate` then increasing.
-        It is computed as:
 
-        ```python
-        decayed_learning_rate = (max_lr - learning_rate) *
-                                (floor(global_step / step_size) - global_step / step_size) +
-                                learning_rate
+        It is computed as::
 
-        ```
-
-    References
-    ----------
-    .. [1] Leslie N. Smith, "Cyclical Learning Rates
-       for Training Neural Networks", https://arxiv.org/abs/1506.01186
-
+            decayed_learning_rate = (max_lr - learning_rate) *
+                                    (floor(global_step / step_size) - global_step / step_size) +
+                                    learning_rate
     """
     with tf.name_scope(name):
         learning_rate = tf.cast(learning_rate, dtype=tf.float32)

--- a/batchflow/models/tf/xception.py
+++ b/batchflow/models/tf/xception.py
@@ -22,6 +22,7 @@ class Xception(TFModel):
     body : dict
         entry, middle, exit : dict
         Dictionary with parameters for entry encoding: downsampling of the inputs.
+
             num_stages : int
                 Number of `block`'s in the respective flow.
             filters : list of sequences of 3 ints

--- a/batchflow/models/torch/base.py
+++ b/batchflow/models/torch/base.py
@@ -49,28 +49,47 @@ DECAYS_DEFAULTS = {
 
 
 class TorchModel(BaseModel):
-    r""" Base class for torch models
+    r""" Base class for Torch models
 
-    **Configuration**
-
-    ``build`` and ``load`` are inherited from :class:`.BaseModel`.
-
-    device : str or torch.device
-        if str, a device name (e.g. 'cpu' or 'gpu:0').
-
+    Parameters
+    ----------
     inputs : dict
-        model inputs (see :meth:`~.TorchModel._make_inputs`)
+        Mapping from placeholder names (e.g. `images`, `labels`, `masks`) to arguments of its initialization.
+        Allows to create placeholders of needed format (shape, dtype, data format) with specified name
+        and apply some typical transformations (like one-hot-encoding), if needed.
 
-    loss - a loss function, might be defined in one of three formats:
-        - name
-        - tuple (name, args)
-        - dict {'name': name, \**args}
+        If value is a string, then it must point to another key from the input-dict, effectively making an alias.
+        By default, `targets` is aliased to `labels` or `masks`, if present.
+        If value is a tuple, then it must contain all of the arguments below in the same order. `None` is reserved
+        for using default value.
+        If value is a dictionary, then it can omit some of the parameters (default values will be at use).
 
-        where name might be one of:
-            - short name (`'mse'`, `'ce'`, `'l1'`, `'cos'`, `'hinge'`, `'huber'`, `'logloss'`, `'dice'`)
+            dtype : str or tf.DType
+                Data type. Default is 'float32'.
+
+            shape : int, None, sequence of ints or Nones
+                Tensor shape with channels and without batch size. Default is None.
+
+            classes : int, array-like or None
+                If int, then number of classes.
+                If array-like, then labels of classes (can be strings or anything else).
+                If None, then tensor has no classes. Default is None.
+
+            data_format : str {'channels_first', 'channels_last', 'f', 'l'}
+                The ordering of the dimensions in the inputs. Can be shortened to ``df`` for brevity.
+                Default is 'channels_last'.
+
+    loss : str, tuple, dict
+        Loss function, might be defined in multiple formats.
+
+        If str, then short ``name``.
+        If tuple, then ``(name, args)``.
+        If dict, then ``{'name': name, **args}``.
+
+        Name must be one of:
+            - short name (e.g. `'mse'`, `'ce'`, `'l1'`, `'cos'`, `'hinge'`, `'huber'`, `'logloss'`, `'dice'`)
             - a class name from `torch losses <https://pytorch.org/docs/stable/nn.html#loss-functions>`_
               (e.g. `'PoissonNLL'` or `'TripletMargin'`)
-            - a module class
             - callable
 
         Examples:
@@ -80,17 +99,38 @@ class TorchModel(BaseModel):
         - ``{'loss': {'name': MyCustomLoss, 'epsilon': 1e-6}}``
         - ``{'loss': my_custom_loss_fn}``
 
-    decay - a learning rate decay algorithm might be defined in one of three formats:
-        - name
-        - tuple (name, args)
-        - dict {'name': name, **args}
+    optimizer : str, tuple, dict
+        Optimizer, might be defined in multiple formats.
 
-        .. note:: All torch decays require to have ```n_iters``` as a key in a configuration
+        If str, then short ``name``.
+        If tuple, then ``(name, args)``.
+        If dict, then ``{'name': name, **args}``.
+
+        Name must be one of:
+            - short name (e.g. 'Adam', 'Adagrad', any optimizer from
+              `torch.optim <https://pytorch.org/docs/stable/optim.html#algorithms>`_)
+            - a class with ``Optimizer`` interface
+            - a callable which takes model parameters and optional args
+
+        Examples:
+
+        - ``{'optimizer': 'Adam'}``
+        - ``{'optimizer': ('SparseAdam', {'lr': 0.01})}``
+        - ``{'optimizer': {'name': 'Adagrad', 'initial_accumulator_value': 0.01}``
+        - ``{'optimizer': {'name': MyCustomOptimizer, momentum=0.95}}``
+
+    decay : str, tuple, dict
+        Learning rate decay algorithm, might be defined in multiple formats.
+        All decays require to have ``n_iters`` as a key in a configuration
         dictionary that contains the number of iterations in one epoch.
 
-        where name might be one of:
+        If str, then short ``name``.
+        If tuple, then ``(name, args)``.
+        If dict, then ``{'name': name, **args}``.
 
-        - short name (`'exp'`, `'lambda'`, `'step'`, `'multistep'`, `'cos'`, `'cyclic'`)
+        Name must be one of:
+
+        - short name ('exp', 'invtime', 'naturalexp', 'const', 'poly')
         - a class name from `torch.optim.lr_scheduler
           <https://pytorch.org/docs/stable/optim.html#how-to-adjust-learning-rate>`_
           (e.g. 'LambdaLR') except `ReduceLROnPlateau`.
@@ -103,34 +143,16 @@ class TorchModel(BaseModel):
         - ``{'decay': ('StepLR', {'steps_size': 10000})}``
         - ``{'decay': {'name': MyCustomDecay, 'decay_rate': .5}``
 
-    optimizer - an optimizer might be defined in one of three formats:
-            - name
-            - tuple (name, args)
-            - dict {'name': name, \**args}
-
-            where name might be one of:
-
-            - short name (e.g. 'Adam', 'Adagrad', any optimizer from
-              `torch.optim <https://pytorch.org/docs/stable/optim.html#algorithms>`_)
-            - a class with ``Optimizer`` interface
-            - a callable which takes model parameters and optional args.
-
-        Examples:
-
-        - ``{'optimizer': 'Adam'}``
-        - ``{'optimizer': ('SparseAdam', {'lr': 0.01})}``
-        - ``{'optimizer': {'name': 'Adagrad', 'initial_accumulator_value': 0.01}``
-        - ``{'optimizer': {'name': MyCustomOptimizer, momentum=0.95}}``
+    device : str or torch.device
+        If str, a device name (e.g. 'cpu' or 'gpu:0').
 
     microbatch : int
-        make forward/backward pass with microbatches of a given size, but apply gradients after the whole batch.
-        Batch size should be evenly divisible by microbatch size.
-
-    common : dict
-        default parameters for all blocks (see :class:`.ConvBlock`)
+        Size of chunks to split every batch in. Allows to process given data sequentially, accumulating gradients
+        from microbatches and applying them once in the end. Can be changed later in the `train` method.
+        Batch size must be divisible by microbatch size.
 
     initial_block : dict or nn.Module
-        a user-defined module or parameters for the input block, usually :class:`.ConvBlock` parameters.
+        User-defined module or parameters for the input block, usually :class:`~.torch.layers.ConvBlock` parameters.
 
         The only required parameter here is ``initial_block/inputs`` which should contain a name or
         a list of names from ``inputs`` which tensors will be passed to ``initial_block`` as ``inputs``.
@@ -143,60 +165,58 @@ class TorchModel(BaseModel):
         - ``{'initial_block': MyCustomModule(some_param=1, another_param=2)}``
 
     body : dict or nn.Module
-        a user-defined module or parameters for the base network layers, usually :class:`.ConvBlock` parameters
+        User-defined module or parameters for the base network layers,
+        usually :class:`~.torch.layers.ConvBlock` parameters.
 
     head : dict or nn.Module
-        a user-defined module or parameters for the head layers, usually :class:`.ConvBlock` parameters
+        User-defined module or parameters for the head layers, usually :class:`~.torch.layers.ConvBlock` parameters.
 
     predictions : str or callable
-        an operation applied to the head output to make the predictions tensor which is used in the loss function.
+        An operation applied to the head output to make the predictions tensor which is used in the loss function.
+        See :meth:`.TorchModel.output` for details.
 
     output : dict or list
-        auxiliary operations
+        Auxiliary operations to apply to network predictions. See :meth:`.TorchModel.output` for details.
 
-    For more details about predictions and auxiliary output operations see :meth:`.TorchModel.output`.
+    common : dict
+        Default parameters for all blocks (see :class:`~.torch.layers.ConvBlock`).
 
-    **How to create your own model**
 
-    #. Take a look at :class:`~.ConvBlock` since it is widely used as a building block almost everywhere.
+    **In order to create your own model, it is recommended to:**
 
-    #. Define model defaults (e.g. number of filters, batch normalization options, etc)
-       by overriding :meth:`.TorchModel.default_config`.
-       Or skip it and hard code all the parameters in unpredictable places without the possibility to
-       change them easily through model's config.
+    * Take a look at :class:`.BaseModel`: ``build`` and ``load`` methods inherited from it.
 
-    #. Define build configuration (e.g. number of classes, etc)
-       by overriding :meth:`~.TorchModel.build_config`.
+    * Take a look at :class:`~.torch.layers.ConvBlock` since it is widely used as a building block almost everywhere.
 
-    #. Override :meth:`~.TorchModel.initial_block`, :meth:`~.TorchModel.body` and :meth:`~.TorchModel.head`, if needed.
-       In many cases defaults and build config are just enough to build a network without additional code writing.
+    * Define model defaults (e.g. number of filters, dropout rates, etc) by overriding
+      :meth:`.TorchModel.default_config`. Those parameters are updated with external configuration dictionary.
 
-    Things worth mentioning:
+    * Define config post-processing by overriding :meth:`~.TorchModel.build_config`.
+      It's main use is to infer parameters that can't be known in advance (e.g. number of classes, shape of inputs).
 
-    #. Input data and its parameters should be defined in configuration under ``inputs`` key.
-       See :meth:`.TorchModel._make_inputs` for details.
+    * Override :meth:`~.TorchModel.initial_block`, :meth:`~.TorchModel.body` and :meth:`~.TorchModel.head`, if needed.
+      You can either use usual `Torch layers <https://pytorch.org/docs/stable/nn.html>`_,
+      or predefined layers like :class:`~torch.layers.PyramidPooling`.
+      Conveniently, 'initial_block' is used to make pre-processing (e.g. reshaping or agressive pooling) of inputs,
+      'body' contains the meat of the network flow,
+      and 'head' makes sure that the output is compatible with targets.
 
-    #. You might want to use a convenient multidimensional :class:`.ConvBlock`,
-       as well as other predefined layers from ``dataset.models.torch.layers``.
-       Of course, you can use usual `Torch layers <https://pytorch.org/docs/stable/nn.html>`_.
 
-    #. In many cases there is no need to write a loss function, learning rate decay and optimizer
-       as they might be defined through config.
+    **In order to use existing model, it is recommended to configure:**
 
-    #. For a configured loss to work one of the inputs should have a name ``targets`` and
-       the model output is considered ``predictions``.
-       They will be passed to a loss function.
+    * ``inputs`` key defines input data together with parameters like shape, dtype, number of classes.
+      For a configured loss to work one of the inputs should have a name ``targets`` and
+      the model output is considered ``predictions``. See :meth:`.TorchModel._make_inputs` for details.
 
-    #. Default values for a learning rate decay algorithms are following:
-       ==========  ==========
-       Decay name  Parameters
-       ==========  ==========
-       exp         gamma = 0.96
-       lambda      lr_lambda = lambda epoch: 0.96**epoch
-       step        step_size = 30
-       multistep   milestones = [30, 80]
-       cos         T_max = n_iters
-       ==========  ==========
+    * ``loss``, ``optimizer``, ``decay`` keys
+
+    * ``initial_block`` sub-dictionary must contain ``inputs`` key with names of tensors to use as network inputs.
+
+    * ``initial_block``, ``body``, ``head`` keys are used to define behaviour of respective part of the network.
+      Default behaviour is to support all of the :class:`~.torch.layers.ConvBlock` options.
+      For complex models, take a look at default config of the chosen model to learn
+      which parameters should be configured.
+
     """
     def __init__(self, *args, **kwargs):
         self._train_lock = threading.Lock()
@@ -459,7 +479,7 @@ class TorchModel(BaseModel):
 
     @classmethod
     def default_config(cls):
-        """ Define model defaults
+        """ Define model defaultsю
 
         You need to override this method if you expect your model or its blocks to serve as a base for other models
         (e.g. VGG for FCN, ResNet for LinkNet, etc).
@@ -467,13 +487,15 @@ class TorchModel(BaseModel):
         Put here all constants (like the number of filters, kernel sizes, block layouts, strides, etc)
         specific to the model, but independent of anything else (like image shapes, number of classes, etc).
 
-        These defaults can be changed in :meth:`~.TorchModel.build_config` or when calling :meth:`.Pipeline.init_model`.
+        These defaults can be changed in :meth:`~.TFModel.build_config` or when calling :meth:`.Pipeline.init_model`.
 
-        Usually, it looks like::
+        Examples
+        --------
+        .. code-block:: python
 
             @classmethod
             def default_config(cls):
-                config = TorchModel.default_config()
+                config = TFModel.default_config()
                 config['initial_block'] = dict(layout='cnap', filters=16, kernel_size=7, strides=2,
                                                pool_size=3, pool_strides=2)
                 config['body/filters'] = 32
@@ -503,27 +525,22 @@ class TorchModel(BaseModel):
         return config
 
     def build_config(self, names=None):
-        """ Define a model architecture configuration
+        """ Define a model architecture configuration.
 
-        It takes just 2 steps:
+        * Don't forget to call ``super().build_config(names)`` in the beginning.
 
-        #. Define names for input data and make input tensors by calling ``super().build_config(names)``.
+        * Define parameters for :meth:`.TFModel.initial_block`, :meth:`.TFModel.body`, :meth:`.TFModel.head`,
+          which depend on inputs.
 
-           If the model config does not contain any name from ``names``, :exc:`KeyError` is raised.
+        * Dont forget to return ``config`` at the end.
 
-           See :meth:`._TorchModel.make_inputs` for details.
-
-        #. Define parameters for :meth:`~.TorchModel.initial_block`, :meth:`~.TorchModel.body`,
-           :meth:`~.TorchModel.head` which depend on inputs.
-
-        #. Don't forget to return ``config``.
-
-        Typically it looks like this::
+        Examples
+        --------
+        .. code-block:: python
 
             def build_config(self, names=None):
-                names = names or ['images', 'labels']
                 config = super().build_config(names)
-                config['head/num_classes'] = self.num_classes('targets')
+                config['head']['num_classes'] = self.num_classes('targets')
                 return config
         """
         config = self.default_config()
@@ -564,11 +581,12 @@ class TorchModel(BaseModel):
 
     @classmethod
     def initial_block(cls, **kwargs):
-        """ Transform inputs with a convolution block
+        """ Transform inputs with a convolution block. Usually used for initial preprocessing,
+        e.g. reshaping, downsampling etc.
 
         Notes
         -----
-        For parameters see :class:`.ConvBlock`.
+        For parameters see :class:`~.torch.layers.ConvBlock`.
 
         Returns
         -------
@@ -581,11 +599,11 @@ class TorchModel(BaseModel):
 
     @classmethod
     def body(cls, **kwargs):
-        """ Base layers which produce a network embedding
+        """ Base layers which produce a network embedding.
 
         Notes
         -----
-        For parameters see :class:`.ConvBlock`.
+        For parameters see :class:`~.torch.layers.ConvBlock`.
 
         Returns
         -------
@@ -598,11 +616,12 @@ class TorchModel(BaseModel):
 
     @classmethod
     def head(cls, **kwargs):
-        """ The last network layers which produce predictions
+        """ The last network layers which produce predictions. Usually used to make network output
+        compatible with the `targets` tensor.
 
         Notes
         -----
-        For parameters see :class:`.ConvBlock`.
+        For parameters see :class:`~.torch.layers.ConvBlock`.
 
         Returns
         -------
@@ -622,21 +641,24 @@ class TorchModel(BaseModel):
             input tensors
 
         predictions : str or callable
-            an operation applied to inputs to get `predictions` tensor which is used in a loss function:
+            Operation to apply to the network output to obtain tensor which is used in loss computation.
 
-            - 'sigmoid' - ``sigmoid(inputs)``
-            - 'proba' - ``softmax(inputs)``
-            - 'labels' - ``argmax(inputs)``
-            - 'softplus' - ``softplus(inputs)``
-            - callable - a user-defined operation
+            If str, then one of predefined operations:
+                - 'sigmoid' - ``sigmoid(inputs)``
+                - 'proba' - ``softmax(inputs)``
+                - 'labels' - ``argmax(inputs)``
+                - 'softplus' - ``softplus(inputs)``
 
-        ops : a sequence of operations or an ordered dict
-            auxiliary operations
+            If callable, then user-defined operation.
 
-            If dict:
+        ops : sequence, dict or OrderedDict
+            Auxiliary operations to apply.
 
-            - key - a prefix for each input
-            - value - a sequence of aux operations
+            If sequence, then operations to apply. Transformed tensors are stored with the same name, as operation
+            If dict, then mapping from prefixes to operations. Transformed tensors are stored with
+            the prefixed name of the operation.
+
+            For multi-output models ensure that an ordered dict is used (e.g. :class:`~collections.OrderedDict`).
 
         Raises
         ------
@@ -645,8 +667,7 @@ class TorchModel(BaseModel):
 
         Examples
         --------
-
-        ::
+        .. code-block:: python
 
             config = {
                 'output': ['proba', 'labels']
@@ -655,15 +676,15 @@ class TorchModel(BaseModel):
         However, if one of the placeholders also has a name 'labels', then it will be lost as the model
         will rewrite the name 'labels' with an output.
 
-        That is where a dict might be convenient::
+        That is where a dict might be convenient:
+
+        .. code-block:: python
 
             config = {
                 'output': {'predicted': ['proba', 'labels']}
             }
 
         Now the output will be stored under names 'predicted_proba' and 'predicted_labels'.
-
-        For multi-output models ensure that an ordered dict is used (e.g. :class:`~collections.OrderedDict`).
         """
         if ops is None:
             ops = []
@@ -780,27 +801,25 @@ class TorchModel(BaseModel):
         Parameters
         ----------
         args
-            arguments to be passed directly into the model
+            Arguments to be passed directly into the model.
 
         fetches : tuple, list
-            a sequence of tensor names to calculate and return
+            Sequence of tensor names to calculate and return.
 
         use_lock : bool
-            if True, the whole train step is locked, thus allowing for multithreading.
+            If True, the whole train step is locked, thus allowing for multithreading.
 
         microbatch : int or None
-            make forward/backward pass with microbatches of a given size, but apply gradients after the whole batch.
-            Batch size should be evenly divisible by microbatch size.
+            Size of chunks to split every batch in. Allows to process given data sequentially, accumulating gradients
+            from microbatches and applying them once in the end.
 
         Returns
         -------
-        Calculated values of tensors in `fetches` in the same structure
-
+        Calculated values of tensors in `fetches` in the same structure.
 
         Examples
         --------
-
-        ::
+        .. code-block:: python
 
             model.train(B('images'), B('labels'), fetches='loss')
         """
@@ -859,35 +878,29 @@ class TorchModel(BaseModel):
         return output
 
     def predict(self, *args, targets=None, fetches=None):    # pylint: disable=arguments-differ
-        """ Get predictions on the data provided
+        """ Get predictions on the data provided.
 
         Parameters
         ----------
-        args
-            arguments to be passed directly into the model
+        args : sequence
+            Arguments to be passed directly into the model.
 
-        targets
-            (optional) targets to calculate loss
+        targets : ndarray, optional
+            Targets to calculate loss.
 
         fetches : tuple, list
-            a sequence of tensors to fetch from the model
+            Sequence of tensors to fetch from the model.
 
         use_lock : bool
-            if True, the whole train step is locked, thus allowing for multithreading.
-
-        microbatch : int or None
-            make forward/backward pass with microbatches of a given size, but apply gradients after the whole batch.
-            Batch size should be evenly divisible by microbatch size.
+            If True, the whole train step is locked, thus allowing for multithreading.
 
         Returns
         -------
-        Calculated values of tensors in `fetches` in the same structure
-
+        Calculated values of tensors in `fetches` in the same structure.
 
         Examples
         --------
-
-        ::
+        .. code-block:: python
 
             model.predict(B('images'), targets=B('labels'), fetches='loss')
         """
@@ -916,17 +929,20 @@ class TorchModel(BaseModel):
         Parameters
         ----------
         path : str
-            a path to a file where the model data will be stored
+            Path to a file where the model data will be stored.
 
         Examples
         --------
-        >>> torch_model = ResNet34()
+        .. code-block:: python
+            torch_model = ResNet34()
 
         Now save the model
 
-        >>> torch_model.save('/path/to/models/resnet34')
+        .. code-block:: python
 
-        The model will be saved to /path/to/models/resnet34
+            torch_model.save('/path/to/models/resnet34')
+
+        The model will be saved to /path/to/models/resnet34.
         """
         _ = args, kwargs
         dirname = os.path.dirname(path)
@@ -941,23 +957,25 @@ class TorchModel(BaseModel):
             }, path)
 
     def load(self, path, *args, eval=False, **kwargs):
-        """ Load a torch model from files
+        """ Load a torch model from files.
 
         Parameters
         ----------
         path : str
-            a file path where a model is stored
+            File path where a model is stored.
 
         eval : bool
-            whether to switch the model to eval mode
+            Whether to switch the model to eval mode.
 
         Examples
         --------
-        >>> resnet = ResNet34(load=dict(path='/path/to/models/resnet34'))
+        .. code-block:: python
 
-        >>> torch_model.load(path='/path/to/models/resnet34')
+            resnet = ResNet34(load=dict(path='/path/to/models/resnet34'))
 
-        >>> TorchModel(config={'device': 'gpu:2', 'load/path': '/path/to/models/resnet34'})
+            torch_model.load(path='/path/to/models/resnet34')
+
+            TorchModel(config={'device': 'gpu:2', 'load/path': '/path/to/models/resnet34'})
 
         **How to move the model to device**
 

--- a/batchflow/models/torch/base.py
+++ b/batchflow/models/torch/base.py
@@ -54,7 +54,7 @@ class TorchModel(BaseModel):
     Parameters
     ----------
     inputs : dict
-        Mapping from placeholder names (e.g. ``images``, ``labels``, ``masks``) to arguments of its initialization.
+        Mapping from placeholder names (e.g. ``images``, ``labels``, ``masks``) to arguments of their initialization.
         Allows to create placeholders of needed format (shape, dtype, data format) with specified name
         and apply some typical transformations (like one-hot-encoding), if needed.
 
@@ -148,7 +148,7 @@ class TorchModel(BaseModel):
         If str, a device name (e.g. 'cpu' or 'gpu:0').
 
     microbatch : int
-        Size of chunks to split every batch in. Allows to process given data sequentially, accumulating gradients
+        Size of chunks to split every batch into. Allows to process given data sequentially, accumulating gradients
         from microbatches and applying them once in the end. Can be changed later in the `train` method.
         Batch size must be divisible by microbatch size.
 
@@ -480,7 +480,7 @@ class TorchModel(BaseModel):
 
     @classmethod
     def default_config(cls):
-        """ Define model defaultsю
+        """ Define model defaults.
 
         You need to override this method if you expect your model or its blocks to serve as a base for other models
         (e.g. VGG for FCN, ResNet for LinkNet, etc).
@@ -488,7 +488,7 @@ class TorchModel(BaseModel):
         Put here all constants (like the number of filters, kernel sizes, block layouts, strides, etc)
         specific to the model, but independent of anything else (like image shapes, number of classes, etc).
 
-        These defaults can be changed in :meth:`~.TFModel.build_config` or when calling :meth:`.Pipeline.init_model`.
+        These defaults can be changed in :meth:`~.TorchModel.build_config` or when calling :meth:`.Pipeline.init_model`.
 
         Examples
         --------
@@ -496,7 +496,7 @@ class TorchModel(BaseModel):
 
             @classmethod
             def default_config(cls):
-                config = TFModel.default_config()
+                config = TorchModel.default_config()
                 config['initial_block'] = dict(layout='cnap', filters=16, kernel_size=7, strides=2,
                                                pool_size=3, pool_strides=2)
                 config['body/filters'] = 32
@@ -526,11 +526,11 @@ class TorchModel(BaseModel):
         return config
 
     def build_config(self, names=None):
-        """ Define a model architecture configuration.
+        """ Define model's architecture configuration.
 
         * Don't forget to call ``super().build_config(names)`` in the beginning.
 
-        * Define parameters for :meth:`.TFModel.initial_block`, :meth:`.TFModel.body`, :meth:`.TFModel.head`,
+        * Define parameters for :meth:`.TorchModel.initial_block`, :meth:`.TorchModel.body`, :meth:`.TorchModel.head`,
           which depend on inputs.
 
         * Dont forget to return ``config`` at the end.
@@ -541,7 +541,7 @@ class TorchModel(BaseModel):
 
             def build_config(self, names=None):
                 config = super().build_config(names)
-                config['head']['num_classes'] = self.num_classes('targets')
+                config['head/num_classes'] = self.num_classes('targets')
                 return config
         """
         config = self.default_config()
@@ -582,8 +582,7 @@ class TorchModel(BaseModel):
 
     @classmethod
     def initial_block(cls, **kwargs):
-        """ Transform inputs with a convolution block. Usually used for initial preprocessing,
-        e.g. reshaping, downsampling etc.
+        """ Transform inputs. Usually used for initial preprocessing, e.g. reshaping, downsampling etc.
 
         Notes
         -----
@@ -675,9 +674,7 @@ class TorchModel(BaseModel):
             }
 
         However, if one of the placeholders also has a name 'labels', then it will be lost as the model
-        will rewrite the name 'labels' with an output.
-
-        That is where a dict might be convenient:
+        will rewrite the name 'labels' with an output. In this case dict might be more convenient:
 
         .. code-block:: python
 
@@ -811,12 +808,12 @@ class TorchModel(BaseModel):
             If True, the whole train step is locked, thus allowing for multithreading.
 
         microbatch : int or None
-            Size of chunks to split every batch in. Allows to process given data sequentially, accumulating gradients
+            Size of chunks to split every batch into. Allows to process given data sequentially, accumulating gradients
             from microbatches and applying them once in the end.
 
         Returns
         -------
-        Calculated values of tensors in `fetches` in the same structure.
+        Calculated values of tensors in `fetches` in the same order.
 
         Examples
         --------
@@ -897,7 +894,7 @@ class TorchModel(BaseModel):
 
         Returns
         -------
-        Calculated values of tensors in `fetches` in the same structure.
+        Calculated values of tensors in `fetches` in the same order.
 
         Examples
         --------

--- a/batchflow/models/torch/base.py
+++ b/batchflow/models/torch/base.py
@@ -83,8 +83,8 @@ class TorchModel(BaseModel):
         Loss function, might be defined in multiple formats.
 
         If str, then short ``name``.
-        If tuple, then ``(name, args)``.
-        If dict, then ``{'name': name, **args}``.
+        If tuple, then ``(name, *args)``.
+        If dict, then ``{'name': name, **kwargs}``.
 
         Name must be one of:
             - short name (e.g. ``'mse'``, ``'ce'``, ``'l1'``, ``'cos'``, ``'hinge'``,
@@ -104,8 +104,8 @@ class TorchModel(BaseModel):
         Optimizer, might be defined in multiple formats.
 
         If str, then short ``name``.
-        If tuple, then ``(name, args)``.
-        If dict, then ``{'name': name, **args}``.
+        If tuple, then ``(name, *args)``.
+        If dict, then ``{'name': name, **kwargs}``.
 
         Name must be one of:
             - short name (e.g. ``'Adam'``, ``'Adagrad'``, any optimizer from
@@ -126,8 +126,8 @@ class TorchModel(BaseModel):
         dictionary that contains the number of iterations in one epoch.
 
         If str, then short ``name``.
-        If tuple, then ``(name, args)``.
-        If dict, then ``{'name': name, **args}``.
+        If tuple, then ``(name, *args)``.
+        If dict, then ``{'name': name, **kwargs}``.
 
         Name must be one of:
 

--- a/batchflow/models/torch/base.py
+++ b/batchflow/models/torch/base.py
@@ -49,22 +49,22 @@ DECAYS_DEFAULTS = {
 
 
 class TorchModel(BaseModel):
-    r""" Base class for Torch models
+    r""" Base class for Torch models.
 
     Parameters
     ----------
     inputs : dict
-        Mapping from placeholder names (e.g. `images`, `labels`, `masks`) to arguments of its initialization.
+        Mapping from placeholder names (e.g. ``images``, ``labels``, ``masks``) to arguments of its initialization.
         Allows to create placeholders of needed format (shape, dtype, data format) with specified name
         and apply some typical transformations (like one-hot-encoding), if needed.
 
         If value is a string, then it must point to another key from the input-dict, effectively making an alias.
-        By default, `targets` is aliased to `labels` or `masks`, if present.
-        If value is a tuple, then it must contain all of the arguments below in the same order. `None` is reserved
+        By default, ``targets`` is aliased to ``labels`` or ``masks``, if present.
+        If value is a tuple, then it must contain all of the arguments below in the same order. ``None`` is reserved
         for using default value.
         If value is a dictionary, then it can omit some of the parameters (default values will be at use).
 
-            dtype : str or tf.DType
+            dtype : str or torch.dtype
                 Data type. Default is 'float32'.
 
             shape : int, None, sequence of ints or Nones
@@ -75,7 +75,7 @@ class TorchModel(BaseModel):
                 If array-like, then labels of classes (can be strings or anything else).
                 If None, then tensor has no classes. Default is None.
 
-            data_format : str {'channels_first', 'channels_last', 'f', 'l'}
+            data_format : {'channels_first', 'channels_last', 'f', 'l'}
                 The ordering of the dimensions in the inputs. Can be shortened to ``df`` for brevity.
                 Default is 'channels_last'.
 
@@ -87,9 +87,10 @@ class TorchModel(BaseModel):
         If dict, then ``{'name': name, **args}``.
 
         Name must be one of:
-            - short name (e.g. `'mse'`, `'ce'`, `'l1'`, `'cos'`, `'hinge'`, `'huber'`, `'logloss'`, `'dice'`)
+            - short name (e.g. ``'mse'``, ``'ce'``, ``'l1'``, ``'cos'``, ``'hinge'``,
+              ``'huber'``, ``'logloss'``, ``'dice'``)
             - a class name from `torch losses <https://pytorch.org/docs/stable/nn.html#loss-functions>`_
-              (e.g. `'PoissonNLL'` or `'TripletMargin'`)
+              (e.g. ``'PoissonNLL'`` or ``'TripletMargin'``)
             - callable
 
         Examples:
@@ -107,7 +108,7 @@ class TorchModel(BaseModel):
         If dict, then ``{'name': name, **args}``.
 
         Name must be one of:
-            - short name (e.g. 'Adam', 'Adagrad', any optimizer from
+            - short name (e.g. ``'Adam'``, ``'Adagrad'``, any optimizer from
               `torch.optim <https://pytorch.org/docs/stable/optim.html#algorithms>`_)
             - a class with ``Optimizer`` interface
             - a callable which takes model parameters and optional args
@@ -130,10 +131,10 @@ class TorchModel(BaseModel):
 
         Name must be one of:
 
-        - short name ('exp', 'invtime', 'naturalexp', 'const', 'poly')
+        - short name (``'exp'``, ``'invtime'``, ``'naturalexp'``, ``'const'``, ``'poly'``)
         - a class name from `torch.optim.lr_scheduler
           <https://pytorch.org/docs/stable/optim.html#how-to-adjust-learning-rate>`_
-          (e.g. 'LambdaLR') except `ReduceLROnPlateau`.
+          (e.g. ``'LambdaLR'``) except ``'ReduceLROnPlateau'``.
         - a class with ``_LRScheduler`` interface
         - a callable which takes optimizer and optional args
 
@@ -934,6 +935,7 @@ class TorchModel(BaseModel):
         Examples
         --------
         .. code-block:: python
+
             torch_model = ResNet34()
 
         Now save the model

--- a/batchflow/models/torch/layers/conv_block.py
+++ b/batchflow/models/torch/layers/conv_block.py
@@ -182,6 +182,7 @@ class ConvBlock(nn.Module):
 
         x = conv_block('cna cna cna', filters=[64, 128, 256], kernel_size=3, activation='selu', batch_norm=False,
                        inputs=previous_layer)
+
     ::
 
         x = conv_block('ca ca ca nd', [32, 32, 64], [5, 3, 3], strides=[1, 1, 2], dropout_rate=.15, inputs=prev_layer)

--- a/batchflow/models/torch/squeezenet.py
+++ b/batchflow/models/torch/squeezenet.py
@@ -165,7 +165,7 @@ class FireBlock(nn.Module):
 
     Notes
     -----
-    For other params see :class:`.ConvBlock`.
+    For other params see :class:`~.torch.layers.ConvBlock`.
     """
     def __init__(self, inputs, layout='cna', filters=None, **kwargs):
         super().__init__()

--- a/batchflow/named_expr.py
+++ b/batchflow/named_expr.py
@@ -656,7 +656,7 @@ class I(NamedExpression):
     Parameters
     ----------
     name : str
-        One of predefined values:
+        Determines returned value. One of:
             - 'current' or its substring - current iteration number, default.
             - 'maximum' or its substring - total number of iterations to be performed.
               If total number is not defined, raises an error.

--- a/batchflow/named_expr.py
+++ b/batchflow/named_expr.py
@@ -656,16 +656,17 @@ class I(NamedExpression):
     Parameters
     ----------
     name : str
-        'current' or its substring - current iteration number, default.
-        'maximum' or its substring - total number of iterations to be performed.
-                                     If total number is not defined, raises an error.
-        'ratio' or its substring - current iteration divided by a total number of iterations.
+        One of predefined values:
+            - 'current' or its substring - current iteration number, default.
+            - 'maximum' or its substring - total number of iterations to be performed.
+              If total number is not defined, raises an error.
+            - 'ratio' or its substring - current iteration divided by a total number of iterations.
 
     Raises
     ------
     ValueError
-        * If `name` is not valid.
-        * If `name` is 'm' or 'r' and total number of iterations is not defined.
+    If `name` is not valid.
+    If `name` is 'm' or 'r' and total number of iterations is not defined.
     Examples
     --------
     ::

--- a/batchflow/pipeline.py
+++ b/batchflow/pipeline.py
@@ -390,10 +390,8 @@ class Pipeline:
         Parameters
         ----------
         variables : dict or tuple
-            if dict
-                key : str - a variable name,
-                value : dict -  a variable value and init params (see :meth:`.init_variable`)
             if tuple, contains variable names which will have None as default values
+            if dict, then mapping from variable names to values and init params (see :meth:`.init_variable`)
 
         Returns
         -------

--- a/batchflow/research/research.py
+++ b/batchflow/research/research.py
@@ -144,7 +144,7 @@ class Research:
         Parameters
         ----------
         function : callable
-            callable object. must include with following named parameters:
+            callable object. must include following named parameters:
                 experiment : `OrderedDict` of Executable objects
                     all pipelines and functions that were added to Research
                 iteration : int
@@ -473,7 +473,7 @@ class Executable:
 
         If positive int, function will be executed each `step` iterations.
 
-        If str, must be `'#{it}'` or `'last'` where it is int,
+        If str, must be `'#{it}'` or `'last'` where `{it}` is an int,
         the function will be executed at this iteration (zero-based)
 
         If list, must be list of int or str described above

--- a/batchflow/research/research.py
+++ b/batchflow/research/research.py
@@ -144,12 +144,11 @@ class Research:
         Parameters
         ----------
         function : callable
-            callable object with following parameters:
+            callable object. must include with following named parameters:
                 experiment : `OrderedDict` of Executable objects
                     all pipelines and functions that were added to Research
                 iteration : int
                     iteration when function is called
-                **args, **kwargs
         returns : str, list of str or None
             names for function returns to save into results
             if None, `function` will be executed without any saving results and dumping
@@ -468,16 +467,29 @@ class Executable:
         or returns (for function) values are lists of variable values
     path : str
         path to the folder where results will be dumped
-    exec : int, list of ints or None
+    execute : int, list of ints or None
+        If `'last'`, function will be executed just at last iteration (if `iteration + 1 == n_iters`
+        or `StopIteration` was raised)
+
+        If positive int, function will be executed each `step` iterations.
+
+        If str, must be `'#{it}'` or `'last'` where it is int,
+        the function will be executed at this iteration (zero-based)
+
+        If list, must be list of int or str described above
     dump : int, list of ints or None
+        iteration when results will be dumped and cleared. Similar to execute
     to_run : bool
+        if False then `.next_batch()` will be applied to pipeline, else `.run()` and then `.reset("iter")`.
     variables : list
         variables (for pipeline) or returns (for function)
     on_root : bool
-
+        if False, function will be called with parameters `(iteration, experiment, *args, **kwargs)`,
+        else with `(iteration, experiments, *args, **kwargs)` where `experiments` is a list of single experiments
     args : list
-
-    kwargs : dict()
+        other positional arguments
+    kwargs : dict
+        other named arguments
     """
     def __init__(self):
         self.function = None

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,6 @@
+.wy-nav-content {
+max-width: 90vw !important;
+/*max-width: 1400px !important;*/
+max-height: 100%;
+overflow-y: auto;
+}

--- a/docs/api/batchflow.batch_image.rst
+++ b/docs/api/batchflow.batch_image.rst
@@ -10,3 +10,5 @@ ImagesBatch
     :undoc-members:
     :exclude-members: get_pos
     :show-inheritance:
+
+.. automethod:: batchflow.batch_image.ImagesBatch._calc_origin

--- a/docs/api/batchflow.models.tf.activations.rst
+++ b/docs/api/batchflow.models.tf.activations.rst
@@ -1,0 +1,9 @@
+===============================
+batchflow.models.tf.activations
+===============================
+
+.. automodule:: batchflow.models.tf.nn.activations
+    :members:
+    :imported-members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/batchflow.models.tf.base.rst
+++ b/docs/api/batchflow.models.tf.base.rst
@@ -7,5 +7,3 @@ TFModel
     :members:
     :undoc-members:
     :show-inheritance:
-
-.. automethod:: batchflow.models.tf.TFModel._make_inputs

--- a/docs/api/batchflow.models.tf.deeplab.rst
+++ b/docs/api/batchflow.models.tf.deeplab.rst
@@ -1,0 +1,9 @@
+=======
+DeepLab
+=======
+
+.. automodule:: batchflow.models.tf.deeplab
+    :member-order: bysource
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/batchflow.models.tf.densenet.rst
+++ b/docs/api/batchflow.models.tf.densenet.rst
@@ -1,6 +1,6 @@
-========
-DenseNet
-========
+===========================
+DenseNet for classification
+===========================
 
 .. automodule:: batchflow.models.tf.densenet
     :member-order: bysource

--- a/docs/api/batchflow.models.tf.models.rst
+++ b/docs/api/batchflow.models.tf.models.rst
@@ -1,27 +1,53 @@
-======
-Models
-======
+===========
+Base Models
+===========
 
 .. toctree::
 
     batchflow.models.tf.base
+    batchflow.models.tf.encoder_decoder
+
+
+=======================
+Classification networks
+=======================
+
+.. toctree::
+    :includehidden:
+
     batchflow.models.tf.vgg
-    batchflow.models.tf.inception
     batchflow.models.tf.resnet
+    batchflow.models.tf.inception
     batchflow.models.tf.pyramidnet
     batchflow.models.tf.mobilenet
     batchflow.models.tf.squeezenet
     batchflow.models.tf.densenet
     batchflow.models.tf.resattention
+    batchflow.models.tf.xception
 
-    batchflow.models.tf.fcn
+=====================
+Segmentation networks
+=====================
+
+.. toctree::
+
     batchflow.models.tf.unet
-    batchflow.models.tf.linknet
     batchflow.models.tf.vnet
     batchflow.models.tf.densenet_fc
     batchflow.models.tf.refinenet
-    batchflow.models.tf.gcn
+    batchflow.models.tf.deeplab
 
+    batchflow.models.tf.gcn
+    batchflow.models.tf.fcn
+    batchflow.models.tf.linknet
     batchflow.models.tf.faster_rcnn
 
-    batchflow.models.tf.encoder_decoder
+
+=======
+Helpers
+=======
+
+.. toctree::
+
+    batchflow.models.tf.activations
+    batchflow.models.tf.train

--- a/docs/api/batchflow.models.tf.train.rst
+++ b/docs/api/batchflow.models.tf.train.rst
@@ -1,0 +1,9 @@
+=========================
+batchflow.models.tf.train
+=========================
+
+.. automodule:: batchflow.models.tf.nn.train
+    :members:
+    :imported-members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/batchflow.models.tf.xception.rst
+++ b/docs/api/batchflow.models.tf.xception.rst
@@ -1,0 +1,9 @@
+========
+Xception
+========
+
+.. automodule:: batchflow.models.tf.xception
+    :member-order: bysource
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/batchflow.rst
+++ b/docs/api/batchflow.rst
@@ -3,7 +3,7 @@ API
 ===
 
 .. toctree::
-   :maxdepth: 4
+   :maxdepth: 5
 
    batchflow.core
    batchflow.opensets

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,38 +77,15 @@ todo_include_todos = False
 # -- Options for HTML output ----------------------------------------------
 
 # choose html theme with custom css template
-### haiku, classic, bizstyle, sphinx_rtd_theme
 html_theme = 'sphinx_rtd_theme'
 
 
 html_theme_options = {
-   # "rightsidebar": "false"
-#    'collapsiblesidebar': True,
-#    'navigation_depth': 3,
 }
 
 html_static_path = ['_static']
 def setup(app):
     app.add_stylesheet('custom.css')
-
-
-####### alabaster theme ############
-# html_theme = 'alabaster'
-# html_theme_options = {
-#     "github_user": "analysiscenter",
-#     "github_repo": "batchflow",
-#     "github_button": 'true',
-#     "fixed_sidebar": 'true',
-#     "page_width": 'auto',
-#     # "sidebar_width": '20vw'
-# }
-# html_sidebars = {
-#     '**': [
-#         'about.html',
-#         'navigation.html',
-#         'searchbox.html',
-#     ]
-# }
 
 
 autoclass_content = 'class'
@@ -163,7 +140,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'dataset', 'BatchFlow Documentation',
+    (master_doc, 'BatchFlow', 'BatchFlow Documentation',
      [author], 1)
 ]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,43 +76,40 @@ todo_include_todos = False
 
 # -- Options for HTML output ----------------------------------------------
 
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-#
-html_theme = 'classic'
-#html_theme = 'nature'
-html_theme = 'bizstyle'
-#html_theme = 'sphinx_rtd_theme'
+# choose html theme with custom css template
+### haiku, classic, bizstyle, sphinx_rtd_theme
+html_theme = 'sphinx_rtd_theme'
+
 
 html_theme_options = {
-#    "rightsidebar": "false"
+   # "rightsidebar": "false"
 #    'collapsiblesidebar': True,
 #    'navigation_depth': 3,
 }
 
-
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+def setup(app):
+    app.add_stylesheet('custom.css')
 
-# Custom sidebar templates, must be a dictionary that maps document names
-# to template names.
-#
-# This is required for the alabaster theme
-# refs: http://alabaster.readthedocs.io/en/latest/installation.html#sidebars
-"""
-html_theme = 'alabaster'
-html_sidebars = {
-    '**': [
-        'about.html',
-        'navigation.html',
-        'relations.html',  # needs 'show_related': True theme option to display
-        'searchbox.html',
-        'donate.html',
-    ]
-}
-"""
+
+####### alabaster theme ############
+# html_theme = 'alabaster'
+# html_theme_options = {
+#     "github_user": "analysiscenter",
+#     "github_repo": "batchflow",
+#     "github_button": 'true',
+#     "fixed_sidebar": 'true',
+#     "page_width": 'auto',
+#     # "sidebar_width": '20vw'
+# }
+# html_sidebars = {
+#     '**': [
+#         'about.html',
+#         'navigation.html',
+#         'searchbox.html',
+#     ]
+# }
+
 
 autoclass_content = 'class'
 add_module_names = False
@@ -123,7 +120,7 @@ intersphinx_mapping = {
     'scipy': ('http://docs.scipy.org/doc/scipy/reference/', None),
     'pandas': ('http://pandas-docs.github.io/pandas-docs-travis/', None),
 }
-
+autodoc_mock_imports = ['torch']
 viewcode_follow_imported_members = True
 
 # -- Options for HTMLHelp output ------------------------------------------

--- a/docs/intro/tf_models.rst
+++ b/docs/intro/tf_models.rst
@@ -91,7 +91,7 @@ For instance, :class:`~.tf.LinkNet`, :class:`~.tf.GlobalConvolutionNetwork`, and
 head
 ----
 It receives body's output and produces a task-specific result, for instance, class logits for classification.
-The default head consists of one :func:`.conv_block`. So, by specifying a model's config you can
+The default head consists of one :class:`~.tf.layers.ConvBlock`. So, by specifying a model's config you can
 instantiate models for different tasks.
 
 Classification with 10 classes::
@@ -174,7 +174,7 @@ Initial block specifies which inputs flow into the model to turn into prediction
         'initial_block/inputs': 'images',
     }
 
-As the default initial block contains a :func:`~.tf.layers.conv_block`, all its parameters might be also specfied in the config::
+As the default initial block contains a :class:`~.tf.layers.ConvBlock`, all its parameters might be also specfied in the config::
 
     model_config = {
         'initial_block': dict(layout='cnap', filters=64, kernel_size=7, strides=2),
@@ -214,7 +214,7 @@ Body is usually defined as a dict, but might also take a callable::
 
 head
 ----
-For many models head is just another :func:`~.layers.conv_block`. So you may configure layout, the number of filters, dense layer units or other parameters. As usual, it is rarely needed for predefined models.
+For many models head is just another :class:`~.tf.layers.ConvBlock`. So you may configure layout, the number of filters, dense layer units or other parameters. As usual, it is rarely needed for predefined models.
 
 Head can also be defined with a callable.
 
@@ -299,7 +299,7 @@ For more detail see :class:`.TFModel` documentation.
 How to write a custom model
 ===========================
 
-To begin with, take a look at :ref:`conv_block <conv_block>` to find out how to write complex networks in just one line of code.
+To begin with, take a look at :class:`~.tf.layers.ConvBlock` to find out how to write complex networks in just one line of code. Note that there is also :func:`~.tf.layers.conv_block`, that provides functional interface for the class.
 This block is a convenient building block for concise, yet very expressive neural networks.
 
 The simplest case you should avoid
@@ -403,7 +403,7 @@ Things worth mentioning:
 #. Input data and its parameters should be defined in configuration under ``inputs`` key.
    See :meth:`.TFModel._make_inputs` for details.
 
-#. You might want to use a convenient multidimensional :func:`.conv_block` and other predefined :doc:`layers <tf_layers>`.
+#. You might want to use a convenient multidimensional :class:`~.tf.layers.ConvBlock` and other predefined :doc:`layers <tf_layers>`.
    Of course, you can use usual `tensorflow layers <https://www.tensorflow.org/api_docs/python/tf/layers>`_.
 
 #. If you make dropout, batch norm, etc by hand, you might use a predefined ``self.is_training`` tensor.

--- a/docs/intro/torch_models.rst
+++ b/docs/intro/torch_models.rst
@@ -93,7 +93,7 @@ For instance, :class:`~.LinkNet` and :class:`~.GlobalConvolutionNetwork` use :cl
 head
 ----
 It receives body's output and produces a task-specific result, for instance, class logits for classification.
-The default head consists of one :class:`.ConvBlock`. So, by specifying a model's config you can
+The default head consists of one :class:`~.torch.layers.ConvBlock`. So, by specifying a model's config you can
 instantiate models for different tasks.
 
 Classification with 10 classes::
@@ -162,7 +162,7 @@ Initial block specifies which inputs flow into the model to turn into prediction
         'initial_block/inputs': 'images',
     }
 
-As the default initial block contains a :class:`~.ConvBlock`, all its parameters might be also specfied in the config::
+As the default initial block contains a :class:`~.torch.layers.ConvBlock`, all its parameters might be also specfied in the config::
 
     model_config = {
         'initial_block': dict(layout='cnap', filters=64, kernel_size=7, strides=2),
@@ -192,9 +192,9 @@ Body can be specified as `nn.Module` or a dict with parameters for a specific mo
 
 head
 ----
-For many models head is just another :class:`~.ConvBlock`. So you may configure layout, the number of filters, dense layer units or other parameters. As usual, it is rarely needed for predefined models.
+For many models head is just another :class:`~.torch.layers.ConvBlock`. So you may configure layout, the number of filters, dense layer units or other parameters. As usual, it is rarely needed for predefined models.
 
-Head can be specified as `nn.Module` or a dict with :class:`~.ConvBlock` parameters.
+Head can be specified as `nn.Module` or a dict with :class:`~.torch.layers.ConvBlock` parameters.
 
 
 Loss, learning rate decay, optimizer
@@ -239,7 +239,7 @@ For more detail see :class:`.TorchModel` documentation.
 How to write a custom model
 ===========================
 
-To begin with, take a look at :class:`.ConvBlock` to find out how to write complex networks in just one line of code.
+To begin with, take a look at :class:`~.torch.layers.ConvBlock` to find out how to write complex networks in just one line of code.
 This block is a convenient building block for concise, yet very expressive neural networks.
 
 The simplest case you should avoid
@@ -342,7 +342,7 @@ Things worth mentioning:
 #. Input data and its parameters should be defined in configuration under ``inputs`` key.
    See :meth:`.TorchModel._make_inputs` for details.
 
-#. You might want to use a convenient multidimensional :class:`.ConvBlock`,
+#. You might want to use a convenient multidimensional :class:`~.torch.layers.ConvBlock`,
    as well as other predefined layers from ``batchflow.models.torch.layers``.
    Of course, you can use usual `Torch layers <https://pytorch.org/docs/stable/nn.html>`_.
 


### PR DESCRIPTION
This PR:

- Adds and improves a lot of docstrings in `TFModel` and `TorchModel`

- Fixes warnings during docs autogeneration by improving docs of `ImagesBatch`, `Pipeline`, `Research` and `NamedExpressions`. See #414 

- Changes the style of doc to `sphinx_rtd_theme`