### PR TITLE
Add more exception types

### DIFF
--- a/batchflow/dsindex.py
+++ b/batchflow/dsindex.py
@@ -642,7 +642,7 @@ class FilesIndex(DatasetIndex):
 
     def build_from_one_path(self, path, dirs=False, no_ext=False):
         """ Build index from a path/glob. """
-        if not isinstance(path, (str, bytes, os.PathLike)):
+        if not isinstance(path, str):
             raise TypeError('Each path must be a string, instead got {}'.format(path))
 
         check_fn = os.path.isdir if dirs else os.path.isfile

--- a/batchflow/dsindex.py
+++ b/batchflow/dsindex.py
@@ -642,6 +642,9 @@ class FilesIndex(DatasetIndex):
 
     def build_from_one_path(self, path, dirs=False, no_ext=False):
         """ Build index from a path/glob. """
+        if not isinstance(path, (str, bytes, os.PathLike)):
+            raise TypeError('Each path must be a string, instead got {}'.format(path))
+
         check_fn = os.path.isdir if dirs else os.path.isfile
         pathlist = glob.iglob(path, recursive=True)
         _full_index = np.asarray([self.build_key(fname, no_ext) for fname in pathlist if check_fn(fname)])

--- a/batchflow/tests/filesindex_test.py
+++ b/batchflow/tests/filesindex_test.py
@@ -44,9 +44,9 @@ def test_build_index_empty(path, expectation):
         assert len(findex) == 0
         assert isinstance(findex.index, np.ndarray)
 
-@pytest.mark.parametrize('path,error', [(1, TypeError),
-                                        ([2, 3], AttributeError),
-                                        ([None], AttributeError)])
+@pytest.mark.parametrize('path,error', [(1, (TypeError, AttributeError)),
+                                        ([2, 3], (TypeError, AttributeError)),
+                                        ([None], (TypeError, AttributeError))])
 def test_build_index_non_path(path, error):
     """ `path` should be string or list of strings """
     with pytest.raises(error):

--- a/batchflow/tests/filesindex_test.py
+++ b/batchflow/tests/filesindex_test.py
@@ -34,7 +34,7 @@ def files_setup(request):
     return path, folder1, folder2
 
 
-@pytest.mark.parametrize('path,expectation', [['', does_not_raise()],
+@pytest.mark.parametrize('path, expectation', [['', does_not_raise()],
                                               [[], pytest.raises(ValueError)],
                                               [['', ''], does_not_raise()]
                                               ])
@@ -44,9 +44,9 @@ def test_build_index_empty(path, expectation):
         assert len(findex) == 0
         assert isinstance(findex.index, np.ndarray)
 
-@pytest.mark.parametrize('path,error', [(1, (TypeError, AttributeError)),
-                                        ([2, 3], (TypeError, AttributeError)),
-                                        ([None], (TypeError, AttributeError))])
+@pytest.mark.parametrize('path, error', [(1, TypeError),
+                                        ([2, 3], TypeError),
+                                        ([None], TypeError)])
 def test_build_index_non_path(path, error):
     """ `path` should be string or list of strings """
     with pytest.raises(error):

--- a/batchflow/tests/filesindex_test.py
+++ b/batchflow/tests/filesindex_test.py
@@ -35,9 +35,8 @@ def files_setup(request):
 
 
 @pytest.mark.parametrize('path, expectation', [['', does_not_raise()],
-                                              [[], pytest.raises(ValueError)],
-                                              [['', ''], does_not_raise()]
-                                              ])
+                                               [[], pytest.raises(ValueError)],
+                                               [['', ''], does_not_raise()]])
 def test_build_index_empty(path, expectation):
     with expectation:
         findex = FilesIndex(path=path)
@@ -45,8 +44,8 @@ def test_build_index_empty(path, expectation):
         assert isinstance(findex.index, np.ndarray)
 
 @pytest.mark.parametrize('path, error', [(1, TypeError),
-                                        ([2, 3], TypeError),
-                                        ([None], TypeError)])
+                                         ([2, 3], TypeError),
+                                         ([None], TypeError)])
 def test_build_index_non_path(path, error):
     """ `path` should be string or list of strings """
     with pytest.raises(error):


### PR DESCRIPTION
`os.path.split` raises different type of excpetions on python 3.7 and 3.5.

![image](https://user-images.githubusercontent.com/47103382/66115053-be4e2600-e5d8-11e9-96f6-204b0e458ed7.png)
