### PR TITLE
PSPNet

### DIFF
--- a/batchflow/models/tf/__init__.py
+++ b/batchflow/models/tf/__init__.py
@@ -24,3 +24,4 @@ from .pyramidnet import PyramidNet, PyramidNet18, PyramidNet34, PyramidNet50, Py
 from .tf_sampler import TfSampler
 from .xception import Xception, XceptionS, Xception41, Xception64
 from .deeplab import DeepLab, DeepLabXS, DeepLabX8, DeepLabX16
+from .pspnet import PSPNet, PSPNet50

--- a/batchflow/models/tf/__init__.py
+++ b/batchflow/models/tf/__init__.py
@@ -26,4 +26,4 @@ from .xception import Xception, XceptionS, Xception41, Xception64
 from .deeplab import DeepLab, DeepLabXS, DeepLabX8, DeepLabX16
 from .efficientnet import EfficientNetB0, EfficientNetB1, EfficientNetB2, EfficientNetB3, \
     EfficientNetB4, EfficientNetB5, EfficientNetB6, EfficientNetB7
-from .pspnet import PSPNet, PSPNet50
+from .pspnet import PSPNet, PSPNet18, PSPNet34, PSPNet50

--- a/batchflow/models/tf/encoder_decoder.py
+++ b/batchflow/models/tf/encoder_decoder.py
@@ -258,13 +258,14 @@ class EncoderDecoder(TFModel):
         list of tf.Tensors
         """
         base_class = kwargs.pop('base')
-        steps, order, downsample, block_args = cls.pop(['num_stages', 'order', 'downsample', 'blocks'], kwargs)
-        order = ''.join([item[0] for item in order])
 
         if base_class is not None:
             encoder_outputs = base_class.make_encoder(inputs, name=name, **kwargs)
 
         else:
+            steps, order, downsample, block_args = cls.pop(['num_stages', 'order', 'downsample', 'blocks'], kwargs)
+            order = ''.join([item[0] for item in order])
+
             base_block = block_args.get('base')
             with tf.variable_scope(name):
                 x = inputs

--- a/batchflow/models/tf/encoder_decoder.py
+++ b/batchflow/models/tf/encoder_decoder.py
@@ -258,12 +258,13 @@ class EncoderDecoder(TFModel):
         list of tf.Tensors
         """
         base_class = kwargs.pop('base')
+        order = cls.pop('order', kwargs)
 
         if base_class is not None:
             encoder_outputs = base_class.make_encoder(inputs, name=name, **kwargs)
 
         else:
-            steps, order, downsample, block_args = cls.pop(['num_stages', 'order', 'downsample', 'blocks'], kwargs)
+            steps, downsample, block_args = cls.pop(['num_stages', 'downsample', 'blocks'], kwargs)
             order = ''.join([item[0] for item in order])
 
             base_block = block_args.get('base')

--- a/batchflow/models/tf/pspnet.py
+++ b/batchflow/models/tf/pspnet.py
@@ -9,13 +9,13 @@ from .layers import pyramid_pooling
 
 class PSPNet(EncoderDecoder):
     """ PSPNet model archtecture.
-    By default, input is compressed with encoder, then processed via Pyramid Pooling layer,
-    and without further upsampling passed as output.
+    By default, input is compressed with encoder, then processed via pyramid pooling layer,
+    and without further upsampling passed as output through 1x1 convolution.
 
     Parameters
     ----------
     inputs : dict
-        Dictionary with 'images' (see :meth:`~.TFModel._make_inputs`)
+        Dictionary (see :meth:`~.TFModel._make_inputs`).
 
     body : dict
         encoder : dict
@@ -61,7 +61,6 @@ class PSPNet34(PSPNet):
                                        downsample=[[], [0], [], []],
                                        filters=[64, 128, 256, 512])
         return config
-
 
 class PSPNet50(PSPNet):
     """

--- a/batchflow/models/tf/pspnet.py
+++ b/batchflow/models/tf/pspnet.py
@@ -7,11 +7,10 @@ from . import EncoderDecoder, ResNet50
 from .layers import pyramid_pooling
 
 
-
 class PSPNet(EncoderDecoder):
     """ PSPNet model archtecture.
     By default, input is compressed with encoder, then processed via Pyramid Pooling layer,
-    and .................................
+    and without further upsampling passed as output.
 
     Parameters
     ----------
@@ -20,15 +19,13 @@ class PSPNet(EncoderDecoder):
 
     body : dict
         encoder : dict
-        Dictionary with parameters for entry encoding: downsampling of the inputs.
+        Dictionary with parameters for entry encoding or dictionary with
+        base model implementing ``make_encoder`` method.
         See :meth:`~.EncoderDecoder.encoder` arguments.
-
-        embedding : dict
-        Same as :meth:`~.EncoderDecoder.embedding`. Default is to use ASPP.
 
         decoder : dict
         Dictionary with parameters for decoding of compressed representation.
-        See :meth:`~.EncoderDecoder.decoder` arguments. Default is to use bilinear upsampling.
+        See :meth:`~.EncoderDecoder.decoder` arguments. Default is None.
     """
     @classmethod
     def default_config(cls):

--- a/batchflow/models/tf/pspnet.py
+++ b/batchflow/models/tf/pspnet.py
@@ -33,20 +33,23 @@ class PSPNet(EncoderDecoder):
     @classmethod
     def default_config(cls):
         config = super().default_config()
-        config['body/encoder'] = dict(base=None, num_stages=None)
         config['body/embedding'] = dict(base=pyramid_pooling)
         config['body/decoder'] = None
+        config['body/order'] = None
         return config
 
 class PSPNet50(PSPNet):
     """
+    PSPNet with ResNet50 encoder.
     """
     @classmethod
     def default_config(cls):
         config = super().default_config()
-
-        config['body/encoder/blocks'] = dict(base=ResNet50,
-                                             downsampling=[[], [0], [], []],
-                                             filters=[64, 128, 256, 512],
-                                             bottlenck=True)
+        config['initial_block'] += dict(layout='cnap', filters=64, kernel_size=7, strides=2,
+                                        pool_size=3, pool_strides=2)
+        config['body/encoder'] += dict(base=ResNet50,
+                                       order=None,
+                                       downsample=[[], [0], [], []],
+                                       filters=[64, 128, 256, 512],
+                                       bottlenck=True)
         return config

--- a/batchflow/models/tf/pspnet.py
+++ b/batchflow/models/tf/pspnet.py
@@ -3,7 +3,7 @@ Hengshuang Zhao, Jianping Shi, Xiaojuan Qi, Xiaogang Wang, Jiaya Jia.
 "`Pyramid Scene Parsing Network <https://arxiv.org/abs/1612.01105>`_"
 """
 
-from . import EncoderDecoder, ResNet50
+from . import EncoderDecoder, ResNet18, ResNet34, ResNet50
 from .layers import pyramid_pooling
 
 
@@ -32,8 +32,36 @@ class PSPNet(EncoderDecoder):
         config = super().default_config()
         config['body/embedding'] = dict(base=pyramid_pooling)
         config['body/decoder'] = None
-        config['body/order'] = None
         return config
+
+class PSPNet18(PSPNet):
+    """
+    PSPNet with ResNet18 encoder.
+    """
+    @classmethod
+    def default_config(cls):
+        config = super().default_config()
+        config['initial_block'] += dict(layout='cnap', filters=64, kernel_size=7, strides=2,
+                                        pool_size=3, pool_strides=2)
+        config['body/encoder'] += dict(base=ResNet18,
+                                       downsample=[[], [0], [], []],
+                                       filters=[64, 128, 256, 512])
+        return config
+
+class PSPNet34(PSPNet):
+    """
+    PSPNet with ResNet34 encoder.
+    """
+    @classmethod
+    def default_config(cls):
+        config = super().default_config()
+        config['initial_block'] += dict(layout='cnap', filters=64, kernel_size=7, strides=2,
+                                        pool_size=3, pool_strides=2)
+        config['body/encoder'] += dict(base=ResNet34,
+                                       downsample=[[], [0], [], []],
+                                       filters=[64, 128, 256, 512])
+        return config
+
 
 class PSPNet50(PSPNet):
     """
@@ -45,8 +73,6 @@ class PSPNet50(PSPNet):
         config['initial_block'] += dict(layout='cnap', filters=64, kernel_size=7, strides=2,
                                         pool_size=3, pool_strides=2)
         config['body/encoder'] += dict(base=ResNet50,
-                                       order=None,
                                        downsample=[[], [0], [], []],
-                                       filters=[64, 128, 256, 512],
-                                       bottlenck=True)
+                                       filters=[64, 128, 256, 512])
         return config

--- a/batchflow/models/tf/pspnet.py
+++ b/batchflow/models/tf/pspnet.py
@@ -1,0 +1,52 @@
+"""
+Hengshuang Zhao, Jianping Shi, Xiaojuan Qi, Xiaogang Wang, Jiaya Jia.
+"`Pyramid Scene Parsing Network <https://arxiv.org/abs/1612.01105>`_"
+"""
+
+from . import EncoderDecoder, ResNet50
+from .layers import pyramid_pooling
+
+
+
+class PSPNet(EncoderDecoder):
+    """ PSPNet model archtecture.
+    By default, input is compressed with encoder, then processed via Pyramid Pooling layer,
+    and .................................
+
+    Parameters
+    ----------
+    inputs : dict
+        Dictionary with 'images' (see :meth:`~.TFModel._make_inputs`)
+
+    body : dict
+        encoder : dict
+        Dictionary with parameters for entry encoding: downsampling of the inputs.
+        See :meth:`~.EncoderDecoder.encoder` arguments.
+
+        embedding : dict
+        Same as :meth:`~.EncoderDecoder.embedding`. Default is to use ASPP.
+
+        decoder : dict
+        Dictionary with parameters for decoding of compressed representation.
+        See :meth:`~.EncoderDecoder.decoder` arguments. Default is to use bilinear upsampling.
+    """
+    @classmethod
+    def default_config(cls):
+        config = super().default_config()
+        config['body/encoder'] = dict(base=None, num_stages=None)
+        config['body/embedding'] = dict(base=pyramid_pooling)
+        config['body/decoder'] = None
+        return config
+
+class PSPNet50(PSPNet):
+    """
+    """
+    @classmethod
+    def default_config(cls):
+        config = super().default_config()
+
+        config['body/encoder/blocks'] = dict(base=ResNet50,
+                                             downsampling=[[], [0], [], []],
+                                             filters=[64, 128, 256, 512],
+                                             bottlenck=True)
+        return config

--- a/batchflow/models/tf/resnet.py
+++ b/batchflow/models/tf/resnet.py
@@ -107,9 +107,9 @@ class ResNet(TFModel):
             filters = config['initial_block/filters']
             config['body/filters'] = (2 ** np.arange(len(num_blocks)) * filters * width).tolist()
 
-        if config.get['body/downsampling'] is None:
+        if config.get['body/downsample'] is None:
             num_blocks = config['body/num_blocks']
-            config.get['body/downsampling'] = [[]] + [[0]] * (len(num_blocks) - 1)
+            config.get['body/downsample'] = [[]] + [[0]] * (len(num_blocks) - 1)
 
         if config.get('head/units') is None:
             config['head/units'] = self.num_classes('targets')

--- a/batchflow/models/tf/resnet.py
+++ b/batchflow/models/tf/resnet.py
@@ -56,14 +56,14 @@ class ResNet(TFModel):
                 or apply a 1x1 convolution (default is False)
             width_factor : int
                 widening factor to make WideResNet (default=1)
-            resnext : bool
-                whether to use aggregated ResNeXt block (default=False)
-            resnext_factor : int
-                the number of aggregations in ResNeXt block (default=32)
-            bottleneck : bool
-                whether to use bottleneck blocks (1x1,3x3,1x1) or simple (3x3,3x3)
-            bottleneck_factor : int
-                filter shrinking factor in a bottleneck block (default=4)
+            resnext : int or None
+                if None - do not use ResNeXt block
+                if int - number of aggregations in ResNeXt block
+                default is None
+            bottleneck : int or None
+                if None - use simple (3x3,3x3) block
+                if int - filter shrinking factor in a bottleneck block (1x1,3x3,1x1)
+                default is None
             se_block : dict or None
                 params for squeeze-and-excitation blocks, see :meth:`~TFModel.se_block` (default=None)
             post_activation : None or bool or str
@@ -80,10 +80,8 @@ class ResNet(TFModel):
                                         pool_size=3, pool_strides=2)
 
         config['body/block'] = dict(layout=None, post_activation=None, downsample=False,
-                                    bottleneck=False, bottleneck_factor=4,
-                                    width_factor=1, zero_pad=False,
-                                    resnext=False, resnext_factor=32,
-                                    se_block=None)
+                                    bottleneck=None, width_factor=1, zero_pad=False,
+                                    resnext=None, se_block=None)
 
         config['head'] += dict(layout='Vdf', dropout_rate=.4)
 
@@ -130,10 +128,6 @@ class ResNet(TFModel):
             number of filters in each block group
         num_blocks : list of int
             number of blocks in each group
-        bottleneck : bool
-            whether to use a simple or bottleneck block
-        bottleneck_factor : int
-            filter number multiplier for a bottleneck block
         name : str
             scope name
 
@@ -198,14 +192,12 @@ class ResNet(TFModel):
             a factor to increase number of filters to build a wide network
         downsample : bool
             whether to decrease spatial dimensions with strides=2 in the first convolution
-        resnext : bool
-            whether to use an aggregated ResNeXt block
-        resnext_factor : int
-            cardinality for ResNeXt block
-        bottleneck : bool
-            whether to use a simple (`False`) or bottleneck (`True`) block
-        bottleneck_factor : int
-            the filters nultiplier in the bottleneck block
+        resnext : int or None
+            if None - do not use ResNeXt block
+            if int - number of aggregations in ResNeXt block
+        bottleneck : int or None
+            if None - use simple (3x3,3x3) block
+            if int - filter shrinking factor in a bottleneck block (1x1,3x3,1x1)
         se_block : dict or None
             params for squeeze-and-excitation blocks, see :meth:`~TFModel.se_block` (default=None)
         post_activation : str or bool
@@ -222,8 +214,8 @@ class ResNet(TFModel):
         kwargs = cls.fill_params('body/block', **kwargs)
         layout, filters, downsample, zero_pad = cls.pop(['layout', 'filters', 'downsample', 'zero_pad'], kwargs)
         width_factor = cls.pop('width_factor', kwargs)
-        bottleneck, bottleneck_factor = cls.pop(['bottleneck', 'bottleneck_factor'], kwargs)
-        resnext, resnext_factor = cls.pop(['resnext', 'resnext_factor'], kwargs)
+        bottleneck = cls.pop(['bottleneck'], kwargs)
+        resnext = cls.pop(['resnext'], kwargs)
         se_block = cls.pop('se_block', kwargs)
         post_activation = cls.pop('post_activation', kwargs)
         if isinstance(post_activation, bool) and post_activation:
@@ -232,10 +224,10 @@ class ResNet(TFModel):
         with tf.variable_scope(name):
             filters = filters * width_factor
             if resnext:
-                x = cls.next_conv_block(inputs, layout, filters, bottleneck, resnext_factor, name='conv',
-                                        downsample=downsample, bottleneck_factor=bottleneck_factor, **kwargs)
+                x = cls.next_conv_block(inputs, layout, filters, bottleneck, resnext, name='conv',
+                                        downsample=downsample, **kwargs)
             else:
-                x = cls.conv_block(inputs, layout, filters, bottleneck, bottleneck_factor, name='conv',
+                x = cls.conv_block(inputs, layout, filters, bottleneck, name='conv',
                                    downsample=downsample, **kwargs)
 
             data_format = kwargs.get('data_format')
@@ -273,7 +265,7 @@ class ResNet(TFModel):
         return x
 
     @classmethod
-    def conv_block(cls, inputs, layout, filters, bottleneck, bottleneck_factor=None, **kwargs):
+    def conv_block(cls, inputs, layout, filters, bottleneck=None, **kwargs):
         """ ResNet convolution block
 
         Parameters
@@ -286,10 +278,9 @@ class ResNet(TFModel):
             number of output filters
         downsample : bool
             whether to decrease spatial dimensions with strides=2
-        bottleneck : bool
-            whether to use a simple or a bottleneck block
-        bottleneck_factor : int
-            filter count scaling factor
+        bottleneck : int or None
+            if None - use simple (3x3,3x3) block
+            if int - filter shrinking factor in a bottleneck block (1x1,3x3,1x1)
         kwargs : dict
             conv_block parameters
 
@@ -300,7 +291,7 @@ class ResNet(TFModel):
         if layout is None:
             layout = cls.default_layout(bottleneck=bottleneck, filters=filters, **kwargs)
         if bottleneck:
-            x = cls.bottleneck_block(inputs, layout, filters, bottleneck_factor=bottleneck_factor, **kwargs)
+            x = cls.bottleneck_block(inputs, layout, filters, bottleneck=bottleneck, **kwargs)
         else:
             x = cls.simple_block(inputs, layout, filters, **kwargs)
         return x
@@ -335,7 +326,7 @@ class ResNet(TFModel):
         return conv_block(inputs, layout, filters=filters, kernel_size=kernel_size, strides=strides, **kwargs)
 
     @classmethod
-    def bottleneck_block(cls, inputs, layout=None, filters=None, kernel_size=None, bottleneck_factor=4,
+    def bottleneck_block(cls, inputs, layout=None, filters=None, kernel_size=None, bottleneck=None,
                          downsample=False, **kwargs):
         """ A stack of 1x1, 3x3, 1x1 convolutions
 
@@ -350,9 +341,8 @@ class ResNet(TFModel):
             if list, number of filters in each layer.
         kernel_size : int or tuple
             convolution kernel size
-        bottleneck_factor : int
-            scale factor for the number of filters in the last convolution
-            (if filters is int, otherwise is not used)
+        bottleneck : int
+            filter number multiplier for a bottleneck block
         downsample : bool
             whether to decrease spatial dimensions with strides=2
         kwargs : dict
@@ -369,12 +359,12 @@ class ResNet(TFModel):
         else:
             strides = kwargs.pop('strides')
         if isinstance(filters, int):
-            filters = [filters, filters, filters * bottleneck_factor]
+            filters = [filters, filters, filters * bottleneck]
         x = conv_block(inputs, layout, filters=filters, kernel_size=kernel_size, strides=strides, **kwargs)
         return x
 
     @classmethod
-    def next_conv_block(cls, inputs, layout, filters, bottleneck, resnext_factor, name, **kwargs):
+    def next_conv_block(cls, inputs, layout, filters, bottleneck, resnext, name, **kwargs):
         """ ResNeXt convolution block
 
         Parameters
@@ -385,10 +375,11 @@ class ResNet(TFModel):
             a sequence of layers in the block
         filters : int
             number of output filters
-        bottleneck : bool
-            whether to use a simple or a bottleneck block
-        resnext_factor : int
-            cardinality for ResNeXt model
+        bottleneck : int or None
+            if None - use simple (3x3,3x3) block
+            if int - filter shrinking factor in a bottleneck block (1x1,3x3,1x1)
+        resnext : int
+            number of aggregations in ResNeXt block
         name : str
             scope name
         kwargs : dict
@@ -401,18 +392,17 @@ class ResNet(TFModel):
         if bottleneck:
             sub_blocks = []
             with tf.variable_scope(name):
-                out_filters = filters * kwargs['bottleneck_factor']
-                in_filters = out_filters // 2 // resnext_factor
+                out_filters = filters * bottleneck
+                in_filters = out_filters // 2 // resnext
                 filters = [in_filters, in_filters, out_filters]
-                for i in range(resnext_factor):
-                    x = cls.conv_block(inputs, layout, filters=filters, bottleneck=True,
+                for i in range(resnext):
+                    x = cls.conv_block(inputs, layout, filters=filters, bottleneck=bottleneck,
                                        name='next_conv_block-%d' % i, **kwargs)
                     sub_blocks.append(x)
                 x = tf.add_n(sub_blocks)
         else:
-            _filters = resnext_factor * 4
-            x = cls.conv_block(inputs, layout, filters=[_filters, filters], bottleneck=False, name=name, **kwargs)
-
+            _filters = resnext * 4
+            x = cls.conv_block(inputs, layout, filters=[_filters, filters], bottleneck=bottleneck, name=name, **kwargs)
         return x
 
 
@@ -423,7 +413,7 @@ class ResNet18(ResNet):
     def default_config(cls):
         config = ResNet.default_config()
         config['body/num_blocks'] = [2, 2, 2, 2]
-        config['body/block/bottleneck'] = False
+        config['body/block/bottleneck'] = None
         return config
 
 
@@ -433,7 +423,7 @@ class ResNet34(ResNet):
     def default_config(cls):
         config = ResNet.default_config()
         config['body/num_blocks'] = [3, 4, 6, 3]
-        config['body/block/bottleneck'] = False
+        config['body/block/bottleneck'] = None
         return config
 
 
@@ -442,7 +432,7 @@ class ResNet50(ResNet):
     @classmethod
     def default_config(cls):
         config = ResNet34.default_config()
-        config['body/block/bottleneck'] = True
+        config['body/block/bottleneck'] = 4
         return config
 
 
@@ -452,7 +442,7 @@ class ResNet101(ResNet):
     def default_config(cls):
         config = ResNet.default_config()
         config['body/num_blocks'] = [3, 4, 23, 3]
-        config['body/block/bottleneck'] = True
+        config['body/block/bottleneck'] = 4
         return config
 
 
@@ -462,7 +452,7 @@ class ResNet152(ResNet):
     def default_config(cls):
         config = ResNet.default_config()
         config['body/num_blocks'] = [3, 8, 36, 3]
-        config['body/block/bottleneck'] = True
+        config['body/block/bottleneck'] = 4
         return config
 
 
@@ -471,7 +461,7 @@ class ResNeXt18(ResNet):
     @classmethod
     def default_config(cls):
         config = ResNet18.default_config()
-        config['body/block/resnext'] = True
+        config['body/block/resnext'] = 32
         return config
 
 
@@ -480,7 +470,7 @@ class ResNeXt34(ResNet):
     @classmethod
     def default_config(cls):
         config = ResNet34.default_config()
-        config['body/block/resnext'] = True
+        config['body/block/resnext'] = 32
         return config
 
 
@@ -489,7 +479,7 @@ class ResNeXt50(ResNet):
     @classmethod
     def default_config(cls):
         config = ResNet50.default_config()
-        config['body/block/resnext'] = True
+        config['body/block/resnext'] = 32
         return config
 
 
@@ -498,7 +488,7 @@ class ResNeXt101(ResNet):
     @classmethod
     def default_config(cls):
         config = ResNet101.default_config()
-        config['body/block/resnext'] = True
+        config['body/block/resnext'] = 32
         return config
 
 
@@ -507,5 +497,5 @@ class ResNeXt152(ResNet):
     @classmethod
     def default_config(cls):
         config = ResNet152.default_config()
-        config['body/block/resnext'] = True
+        config['body/block/resnext'] = 32
         return config

--- a/batchflow/models/torch/resnet.py
+++ b/batchflow/models/torch/resnet.py
@@ -45,10 +45,6 @@ class ResNet(TorchModel):
             number of filters in each group
 
         block : dict
-            bottleneck : bool
-                whether to use bottleneck blocks (1x1,3x3,1x1) or simple (3x3,3x3)
-            bottleneck_factor : int
-                filter shrinking factor in a bottleneck block (default=4)
             post_activation : None or bool or str
                 layout to apply after after residual and shortcut summation (default is None)
             zero_pad : bool
@@ -56,10 +52,15 @@ class ResNet(TorchModel):
                 or apply a 1x1 convolution (default is False)
             width_factor : int
                 widening factor to make WideResNet (default=1)
-            resnext : bool
-                whether to use aggregated ResNeXt block (default=False)
-            resnext_factor : int
-                the number of aggregations in ResNeXt block (default=32)
+            resnext : int or None
+                if None - do not use ResNeXt block
+                if int - number of aggregations in ResNeXt block
+                default is None
+            bottleneck : int or None
+                if None - use simple (3x3,3x3) block
+                if int - filter shrinking factor in a bottleneck block (1x1,3x3,1x1)
+                default is None
+
 
     head : dict
         'Vdf' with dropout_rate=.4
@@ -72,9 +73,8 @@ class ResNet(TorchModel):
                                         pool_size=3, pool_strides=2)
 
         config['body/block'] = dict(layout=None, post_activation=None, downsample=False,
-                                    bottleneck=False, bottleneck_factor=4,
-                                    width_factor=1, zero_pad=False,
-                                    resnext=False, resnext_factor=32)
+                                    bottleneck=None, width_factor=1, zero_pad=False,
+                                    resnext=False)
 
         config['head'] += dict(layout='Vdf', dropout_rate=.4)
 
@@ -98,6 +98,10 @@ class ResNet(TorchModel):
             filters = config['initial_block/filters']
             config['body/filters'] = (2 ** np.arange(len(num_blocks)) * filters * width).tolist()
 
+        if config.get['body/downsample'] is None:
+            num_blocks = config['body/num_blocks']
+            config.get['body/downsample'] = [[]] + [[0]] * (len(num_blocks) - 1)
+
         if config.get('head/units') is None:
             config['head/units'] = self.num_classes('targets')
         if config.get('head/filters') is None:
@@ -115,25 +119,20 @@ class ResNet(TorchModel):
             number of filters in each block group
         num_blocks : list of int
             number of blocks in each group
-        bottleneck : bool
-            whether to use a simple or bottleneck block
-        bottleneck_factor : int
-            filter number multiplier for a bottleneck block
 
         Returns
         -------
         nn.Module
         """
         kwargs = cls.get_defaults('body', kwargs)
-        filters, block_args = cls.pop(['filters', 'block'], kwargs)
+        filters, block_args, downsample = cls.pop(['filters', 'block', 'downsample'], kwargs)
         block_args = {**kwargs, **block_args}
 
         x = inputs
         all_blocks = []
         for i, n_blocks in enumerate(kwargs['num_blocks']):
             for block in range(n_blocks):
-                downsample = i > 0 and block == 0
-                block_args['downsample'] = downsample
+                block_args['downsample'] = block in downsample[i]
                 bfilters = filters[i] if isinstance(filters[i], int) else filters[i][block]
                 x = cls.block(x, filters=bfilters, **block_args)
                 all_blocks.append(x)
@@ -178,14 +177,12 @@ class ResNet(TorchModel):
             a factor to increase number of filters to build a wide network
         downsample : bool
             whether to decrease spatial dimensions with strides=2 in the first convolution
-        resnext : bool
-            whether to use an aggregated ResNeXt block
-        resnext_factor : int
-            cardinality for ResNeXt block
-        bottleneck : bool
-            whether to use a simple (`False`) or bottleneck (`True`) block
-        bottleneck_factor : int
-            the filters nultiplier in the bottleneck block
+        resnext : int or None
+            if None - do not use ResNeXt block
+            if int - number of aggregations in ResNeXt block
+        bottleneck : int or None
+            if None - use simple (3x3,3x3) block
+            if int - filter shrinking factor in a bottleneck block (1x1,3x3,1x1)
         kwargs : dict
             ConvBlock parameters for all sub blocks
 
@@ -196,18 +193,18 @@ class ResNet(TorchModel):
         kwargs = cls.get_defaults('body/block', kwargs)
         layout, filters, downsample, zero_pad = cls.pop(['layout', 'filters', 'downsample', 'zero_pad'], kwargs)
         width_factor = cls.pop('width_factor', kwargs)
-        bottleneck, bottleneck_factor = cls.pop(['bottleneck', 'bottleneck_factor'], kwargs)
-        resnext, resnext_factor = cls.pop(['resnext', 'resnext_factor'], kwargs)
+        bottleneck = cls.pop(['bottleneck'], kwargs)
+        resnext = cls.pop(['resnext'], kwargs)
         post_activation = cls.pop('post_activation', kwargs)
         if isinstance(post_activation, bool) and post_activation:
             post_activation = 'an'
 
         filters = filters * width_factor
         if resnext:
-            x = cls.next_conv_block(inputs, layout, filters, bottleneck, resnext_factor,
-                                    downsample=downsample, bottleneck_factor=bottleneck_factor, **kwargs)
+            x = cls.next_conv_block(inputs, layout, filters, bottleneck,
+                                    downsample=downsample, **kwargs)
         else:
-            x = cls.conv_block(inputs, layout, filters, bottleneck, bottleneck_factor,
+            x = cls.conv_block(inputs, layout, filters, bottleneck,
                                downsample=downsample, **kwargs)
 
         inputs_channels = get_num_channels(inputs)
@@ -239,7 +236,7 @@ class ResNet(TorchModel):
         return x
 
     @classmethod
-    def conv_block(cls, inputs, layout, filters, bottleneck, bottleneck_factor=None, **kwargs):
+    def conv_block(cls, inputs, layout, filters, bottleneck=None, **kwargs):
         """ ResNet convolution block
 
         Parameters
@@ -252,10 +249,9 @@ class ResNet(TorchModel):
             number of output filters
         downsample : bool
             whether to decrease spatial dimensions with strides=2
-        bottleneck : bool
-            whether to use a simple or a bottleneck block
-        bottleneck_factor : int
-            filter count scaling factor
+        bottleneck : int or None
+            if None - use simple (3x3,3x3) block
+            if int - filter shrinking factor in a bottleneck block (1x1,3x3,1x1)
         kwargs : dict
             conv_block parameters
 
@@ -266,7 +262,7 @@ class ResNet(TorchModel):
         if layout is None:
             layout = cls.default_layout(bottleneck=bottleneck, filters=filters, **kwargs)
         if bottleneck:
-            x = cls.bottleneck_block(inputs, layout, filters, bottleneck_factor=bottleneck_factor, **kwargs)
+            x = cls.bottleneck_block(inputs, layout, filters, bottleneck=bottleneck, **kwargs)
         else:
             x = cls.simple_block(inputs, layout, filters, **kwargs)
         return x
@@ -299,7 +295,7 @@ class ResNet(TorchModel):
         return ConvBlock(inputs, layout, filters=filters, kernel_size=kernel_size, strides=strides, **kwargs)
 
     @classmethod
-    def bottleneck_block(cls, inputs, layout=None, filters=None, kernel_size=None, bottleneck_factor=4,
+    def bottleneck_block(cls, inputs, layout=None, filters=None, kernel_size=None, bottleneck=None,
                          downsample=False, **kwargs):
         """ A stack of 1x1, 3x3, 1x1 convolutions
 
@@ -314,8 +310,8 @@ class ResNet(TorchModel):
             if list, number of filters in each layer
         kernel_size : int or tuple
             convolution kernel size
-        bottleneck_factor : int
-            scale factor for the number of filters in the last convolution
+        bottleneck : int
+            filter number multiplier for a bottleneck block
             (if filters is int, otherwise is not used)
         downsample : bool
             whether to decrease spatial dimensions with strides=2
@@ -333,12 +329,12 @@ class ResNet(TorchModel):
         else:
             strides = kwargs.pop('strides')
         if isinstance(filters, int):
-            filters = [filters, filters, filters * bottleneck_factor]
+            filters = [filters, filters, filters * bottleneck]
         x = ConvBlock(inputs, layout, filters=filters, kernel_size=kernel_size, strides=strides, **kwargs)
         return x
 
     @classmethod
-    def next_conv_block(cls, inputs, layout, filters, bottleneck, resnext_factor, **kwargs):
+    def next_conv_block(cls, inputs, layout, filters, bottleneck, resnext, **kwargs):
         """ ResNeXt convolution block
 
         Parameters
@@ -347,10 +343,11 @@ class ResNet(TorchModel):
             input tensor
         filters : int
             number of output filters
-        bottleneck : bool
-            whether to use a simple or a bottleneck block
-        resnext_factor : int
-            cardinality for ResNeXt model
+        bottleneck : int or None
+            if None - use simple (3x3,3x3) block
+            if int - filter shrinking factor in a bottleneck block (1x1,3x3,1x1)
+        resnext : int
+            number of aggregations in ResNeXt block
         kwargs : dict
             `ConvBlock` parameters
 
@@ -359,11 +356,11 @@ class ResNet(TorchModel):
         nn.Module
         """
         if bottleneck:
-            filters = filters * kwargs['bottleneck_factor']
+            filters = filters * bottleneck
             filters = [filters // 2, filters // 2, filters]
-            kwargs['groups'] = [1, resnext_factor, 1]
+            kwargs['groups'] = [1, resnext, 1]
         else:
-            filters = [resnext_factor * 4, filters]
+            filters = [resnext * 4, filters]
         x = cls.conv_block(inputs, layout, filters=filters, bottleneck=bottleneck, **kwargs)
         return x
 
@@ -403,7 +400,7 @@ class ResNet18(ResNet):
     def default_config(cls):
         config = ResNet.default_config()
         config['body/num_blocks'] = [2, 2, 2, 2]
-        config['body/block/bottleneck'] = False
+        config['body/block/bottleneck'] = None
         return config
 
 
@@ -413,7 +410,7 @@ class ResNet34(ResNet):
     def default_config(cls):
         config = ResNet.default_config()
         config['body/num_blocks'] = [3, 4, 6, 3]
-        config['body/block/bottleneck'] = False
+        config['body/block/bottleneck'] = None
         return config
 
 
@@ -422,7 +419,7 @@ class ResNet50(ResNet):
     @classmethod
     def default_config(cls):
         config = ResNet34.default_config()
-        config['body/block/bottleneck'] = True
+        config['body/block/bottleneck'] = 4
         return config
 
 
@@ -432,7 +429,7 @@ class ResNet101(ResNet):
     def default_config(cls):
         config = ResNet.default_config()
         config['body/num_blocks'] = [3, 4, 23, 3]
-        config['body/block/bottleneck'] = True
+        config['body/block/bottleneck'] = 4
         return config
 
 
@@ -442,7 +439,7 @@ class ResNet152(ResNet):
     def default_config(cls):
         config = ResNet.default_config()
         config['body/num_blocks'] = [3, 8, 36, 3]
-        config['body/block/bottleneck'] = True
+        config['body/block/bottleneck'] = 4
         return config
 
 class ResNeXt18(ResNet):
@@ -450,7 +447,7 @@ class ResNeXt18(ResNet):
     @classmethod
     def default_config(cls):
         config = ResNet18.default_config()
-        config['body/block/resnext'] = True
+        config['body/block/resnext'] = 32
         return config
 
 
@@ -459,7 +456,7 @@ class ResNeXt34(ResNet):
     @classmethod
     def default_config(cls):
         config = ResNet34.default_config()
-        config['body/block/resnext'] = True
+        config['body/block/resnext'] = 32
         return config
 
 
@@ -468,7 +465,7 @@ class ResNeXt50(ResNet):
     @classmethod
     def default_config(cls):
         config = ResNet50.default_config()
-        config['body/block/resnext'] = True
+        config['body/block/resnext'] = 32
         return config
 
 
@@ -477,7 +474,7 @@ class ResNeXt101(ResNet):
     @classmethod
     def default_config(cls):
         config = ResNet101.default_config()
-        config['body/block/resnext'] = True
+        config['body/block/resnext'] = 32
         return config
 
 
@@ -486,5 +483,5 @@ class ResNeXt152(ResNet):
     @classmethod
     def default_config(cls):
         config = ResNet152.default_config()
-        config['body/block/resnext'] = True
+        config['body/block/resnext'] = 32
         return config

--- a/batchflow/tests/encoder_decoder_test.py
+++ b/batchflow/tests/encoder_decoder_test.py
@@ -19,7 +19,7 @@ MODELS = [
 
 ENCODERS = [
     {'num_stages': 2},
-    {'base': ResNet, 'num_blocks': [2]*3, 'filters': [13]*3},
+    {'base': ResNet, 'num_blocks': [2]*3, 'filters': [13]*3, 'downsample': [[], [0], [0], [0]]},
     {'base': DenseNet, 'num_layers': [2]*3, 'growth_rate': 13},
     {'num_stages': 2, 'blocks': {'base': ResNet.block, 'filters':[13]*2}},
 ]

--- a/batchflow/tests/tf_models_compile_test.py
+++ b/batchflow/tests/tf_models_compile_test.py
@@ -17,7 +17,8 @@ from batchflow.models.tf import LinkNet, UNet, VNet, \
                                 PyramidNet18, PyramidNet34, PyramidNet50, PyramidNet101, \
                                 XceptionS, Xception41, Xception64, \
                                 EfficientNetB0, EfficientNetB1, EfficientNetB2, EfficientNetB3, \
-                                EfficientNetB4, EfficientNetB5, EfficientNetB6, EfficientNetB7
+                                EfficientNetB4, EfficientNetB5, EfficientNetB6, EfficientNetB7, \
+                                PSPNet18, PSPNet34, PSPNet50
 
 
 
@@ -45,7 +46,8 @@ MODELS_SEG = [
     DenseNetFC56, # DenseNetFC67, DenseNetFC103,
     RefineNet,
     GCN,
-    DeepLabXS, DeepLabX8, # DeepLabX16
+    DeepLabXS, DeepLabX8, # DeepLabX16,
+    PSPNet18, # PSPNet34, PSPNet50
 ]
 
 

--- a/pylintrc
+++ b/pylintrc
@@ -16,7 +16,7 @@ docstring-min-length=3
 ignored-modules=numpy,cv2
 
 [MESSAGE CONTROL]
-disable=no-member, no-value-for-parameter, no-self-use, too-many-locals, too-few-public-methods, too-many-public-methods, too-many-branches, unsubscriptable-object, redefined-variable-type, too-many-star-expressions, duplicate-code, not-context-manager, too-many-lines, global-statement, locally-disabled, wrong-import-position, invalid-sequence-index, redundant-keyword-arg, bad-super-call, no-self-argument, redefined-builtin, arguments-differ, len-as-condition, keyword-arg-before-vararg,assignment-from-none,useless-return,useless-import-alias, unnecessary-pass, cyclic-import, assignment-from-no-return, comparison-with-callable, unnecessary-lambda
+disable=no-member, no-value-for-parameter, no-self-use, too-many-locals, too-few-public-methods, too-many-public-methods, too-many-branches, unsubscriptable-object, redefined-variable-type, too-many-star-expressions, duplicate-code, not-context-manager, too-many-lines, global-statement, locally-disabled, wrong-import-position, invalid-sequence-index, redundant-keyword-arg, bad-super-call, no-self-argument, redefined-builtin, arguments-differ, len-as-condition, keyword-arg-before-vararg,assignment-from-none,useless-return,useless-import-alias, unnecessary-pass, cyclic-import, assignment-from-no-return, comparison-with-callable, unnecessary-lambda, import-outside-toplevel
 
 [BASIC]
 class-rgx=[A-Z_][a-zA-Z0-9_]+$


### PR DESCRIPTION
PR proposes following changes:
* introduce a PSPNet model;
* add `body/donwsample` parameter for ResNet models for better control of spatial dimensions: it should be a list of lists with same lenght as `body/num_blocks`, so that each list represents a group. Inner lists contain integers - indices of ResNet blocks that should apply downsampling; empty list indicates that there is no downsampling in group;
* change config parsing in `EncoderDecoder.encoder` method. Now, in case `body/encoder/base` is present, it is built with all kwargs except for `body/encoder/order`. This allowed for control of downsampling scheme in case of ResNet backbone;
* modify tests according to changes decribed above; add test case for PSPNet compilation;
* update pylint exceptions;