### PR TITLE
Regrmetr generate warnings

### DIFF
--- a/batchflow/tests/regression_metrics_test.py
+++ b/batchflow/tests/regression_metrics_test.py
@@ -9,6 +9,7 @@ Verifies the correctness of evaluated metrics for the cases:
 # pylint: disable=missing-docstring
 import pytest
 import numpy as np
+np.seterr(divide='ignore', invalid='ignore')
 
 from batchflow.models.metrics import RegressionMetrics
 


### PR DESCRIPTION
Avoid `numpy` raising warnings in `regression_metrics_tests.py`  since the cases, when the division by zero is encounted,  is explicitly processed in test functions.