### PR TITLE
Fix ResNet models

### DIFF
--- a/batchflow/models/tf/base.py
+++ b/batchflow/models/tf/base.py
@@ -1671,7 +1671,7 @@ class TFModel(BaseModel):
     def _add_output_op(self, inputs, oper, name, attr_prefix, **kwargs):
         device = self._get_current_device()
         if oper is None:
-            self._add_output_identity(inputs, name, attr_prefix[:-1], device, **kwargs)
+            self._add_output_identity(inputs, '', attr_prefix[:-1], device, **kwargs)
         elif oper == 'softplus':
             self._add_output_softplus(inputs, name, attr_prefix, device, **kwargs)
         elif oper == 'sigmoid':

--- a/batchflow/models/tf/base.py
+++ b/batchflow/models/tf/base.py
@@ -1671,7 +1671,7 @@ class TFModel(BaseModel):
     def _add_output_op(self, inputs, oper, name, attr_prefix, **kwargs):
         device = self._get_current_device()
         if oper is None:
-            self._add_output_identity(inputs, '', attr_prefix[:-1], device, **kwargs)
+            self._add_output_identity(inputs, name, attr_prefix[:-1], device, **kwargs)
         elif oper == 'softplus':
             self._add_output_softplus(inputs, name, attr_prefix, device, **kwargs)
         elif oper == 'sigmoid':
@@ -1686,7 +1686,7 @@ class TFModel(BaseModel):
     def _add_output_identity(self, inputs, name, attr_prefix, device, **kwargs):
         _ = kwargs
         x = tf.identity(inputs, name=name)
-        self.store_to_attr(attr_prefix + name, x, device)
+        self.store_to_attr(attr_prefix + (name or ''), x, device)
         return x
 
     def _add_output_softplus(self, inputs, name, attr_prefix, device, **kwargs):

--- a/batchflow/models/tf/resnet.py
+++ b/batchflow/models/tf/resnet.py
@@ -214,8 +214,8 @@ class ResNet(TFModel):
         kwargs = cls.fill_params('body/block', **kwargs)
         layout, filters, downsample, zero_pad = cls.pop(['layout', 'filters', 'downsample', 'zero_pad'], kwargs)
         width_factor = cls.pop('width_factor', kwargs)
-        bottleneck = cls.pop(['bottleneck'], kwargs)
-        resnext = cls.pop(['resnext'], kwargs)
+        bottleneck = cls.pop('bottleneck', kwargs)
+        resnext = cls.pop('resnext', kwargs)
         se_block = cls.pop('se_block', kwargs)
         post_activation = cls.pop('post_activation', kwargs)
         if isinstance(post_activation, bool) and post_activation:

--- a/batchflow/models/torch/base.py
+++ b/batchflow/models/torch/base.py
@@ -712,7 +712,7 @@ class TorchModel(BaseModel):
 
     def _add_output_op(self, inputs, oper, name, attr_prefix, **kwargs):
         if oper is None:
-            self._add_output_identity(inputs, name, attr_prefix[:-1], **kwargs)
+            self._add_output_identity(inputs, '', attr_prefix[:-1], **kwargs)
         elif oper == 'softplus':
             self._add_output_softplus(inputs, name, attr_prefix, **kwargs)
         elif oper == 'sigmoid':

--- a/batchflow/models/torch/base.py
+++ b/batchflow/models/torch/base.py
@@ -712,7 +712,7 @@ class TorchModel(BaseModel):
 
     def _add_output_op(self, inputs, oper, name, attr_prefix, **kwargs):
         if oper is None:
-            self._add_output_identity(inputs, '', attr_prefix[:-1], **kwargs)
+            self._add_output_identity(inputs, name, attr_prefix[:-1], **kwargs)
         elif oper == 'softplus':
             self._add_output_softplus(inputs, name, attr_prefix, **kwargs)
         elif oper == 'sigmoid':
@@ -726,7 +726,7 @@ class TorchModel(BaseModel):
 
     def _add_output_identity(self, inputs, name, attr_prefix, **kwargs):
         _ = kwargs
-        setattr(self, attr_prefix + name, inputs)
+        setattr(self, attr_prefix + (name or ''), inputs)
         return inputs
 
     def _add_output_softplus(self, inputs, name, attr_prefix, **kwargs):

--- a/batchflow/models/torch/resnet.py
+++ b/batchflow/models/torch/resnet.py
@@ -98,9 +98,9 @@ class ResNet(TorchModel):
             filters = config['initial_block/filters']
             config['body/filters'] = (2 ** np.arange(len(num_blocks)) * filters * width).tolist()
 
-        if config.get['body/downsample'] is None:
+        if config.get('body/downsample') is None:
             num_blocks = config['body/num_blocks']
-            config.get['body/downsample'] = [[]] + [[0]] * (len(num_blocks) - 1)
+            config['body/downsample'] = [[]] + [[0]] * (len(num_blocks) - 1)
 
         if config.get('head/units') is None:
             config['head/units'] = self.num_classes('targets')
@@ -193,8 +193,8 @@ class ResNet(TorchModel):
         kwargs = cls.get_defaults('body/block', kwargs)
         layout, filters, downsample, zero_pad = cls.pop(['layout', 'filters', 'downsample', 'zero_pad'], kwargs)
         width_factor = cls.pop('width_factor', kwargs)
-        bottleneck = cls.pop(['bottleneck'], kwargs)
-        resnext = cls.pop(['resnext'], kwargs)
+        bottleneck = cls.pop('bottleneck', kwargs)
+        resnext = cls.pop('resnext', kwargs)
         post_activation = cls.pop('post_activation', kwargs)
         if isinstance(post_activation, bool) and post_activation:
             post_activation = 'an'


### PR DESCRIPTION
* This PR fixes bugs carefully placed in ResNet architectures in #434. 
* Also, it changes the way `_add_output_identity` handles its argument `name`: this argument is `None`, so upon concatenation with string argument `attr_prefix` it caused an error. This PR suggests to replace  `None` with empty string right before concatenation.