### PR TITLE
Add ResearchExperimentPath

### DIFF
--- a/batchflow/research/__init__.py
+++ b/batchflow/research/__init__.py
@@ -4,6 +4,7 @@ from .distributor import Distributor
 from .logger import Logger, BasicLogger, PrintLogger, TelegramLogger
 from .workers import Worker, PipelineWorker
 from .named_expr import ResearchNamedExpression, ResearchExecutableUnit, ResearchPipeline, \
-                        ResearchIteration, ResearchConfig, ResearchResults, ResearchPath
+                        ResearchIteration, ResearchConfig, ResearchResults, ResearchPath, \
+                        ResearchExperimentPath
 from .research import Research
 from .results import Results

--- a/batchflow/research/named_expr.py
+++ b/batchflow/research/named_expr.py
@@ -1,5 +1,7 @@
 """ Contains named expression classes for Research """
 
+import os
+
 from .results import Results
 from ..named_expr import NamedExpression
 
@@ -76,6 +78,17 @@ class ResearchPath(ResearchNamedExpression):
     def get(self, **kwargs):
         path = self._get(**kwargs)
         return path
+
+class ResearchExperimentPath(ResearchNamedExpression):
+    """ NamedExpression for path to the current experiment """
+    def _get(self, **kwargs):
+        _, kwargs = super()._get(**kwargs)
+        return kwargs['job'], kwargs['experiment']
+
+    def get(self, **kwargs):
+        job, experiment = self._get(**kwargs)
+        unit = list(experiment.values())[0]
+        return os.path.join(unit.path, job.ids[unit.index])
 
 class ResearchResults(ResearchNamedExpression):
     """ NamedExpression for Results of the Research """


### PR DESCRIPTION
Add ResearchExperimentPath named expression to use the current experiment path in callable, for example, to dump models.