### PR TITLE
Few simple fixes

### DIFF
--- a/batchflow/base.py
+++ b/batchflow/base.py
@@ -161,7 +161,7 @@ class Baseset:
         """ Return iteration params with default values to start iteration from scratch """
         return dict(_stop_iter=False, _start_index=0, _order=None, _n_iters=0, _n_epochs=0, _random_state=None)
 
-    @deprecated("Use reset('iter').")
+    @deprecated("`reset_iter()` is deprecated, use `reset('iter')` instead")
     def reset_iter(self):
         self.reset('iter')
 

--- a/batchflow/batch.py
+++ b/batchflow/batch.py
@@ -425,14 +425,7 @@ class Batch:
         return res
 
     def __getitem__(self, item):
-        item_pos = self.index.get_pos(item)
-        if isinstance(self.data, np.ndarray):
-            return self.data[item_pos]
-        elif isinstance(self.data, pd.DataFrame):
-            return self.data.iloc[item_pos]
-        elif self.data is None:
-            return None
-        return self.data[item]
+        return self.data[item] if self.data is not None else None
 
     def __iter__(self):
         for item in self.indices:

--- a/batchflow/batch.py
+++ b/batchflow/batch.py
@@ -956,7 +956,6 @@ class Batch:
         _ = args
 
         if dst is not None:
-            components = (dst,) if isinstance(dst, str) else dst
             self.add_components(np.setdiff1d(components, self.components).tolist())
 
         if fmt is None:

--- a/batchflow/batch.py
+++ b/batchflow/batch.py
@@ -425,7 +425,14 @@ class Batch:
         return res
 
     def __getitem__(self, item):
-        return self.data[item] if self.data is not None else None
+        item_pos = self.index.get_pos(item)
+        if isinstance(self.data, np.ndarray):
+            return self.data[item_pos]
+        elif isinstance(self.data, pd.DataFrame):
+            return self.data.iloc[item_pos]
+        elif self.data is None:
+            return None
+        return self.data[item]
 
     def __iter__(self):
         for item in self.indices:

--- a/batchflow/batch.py
+++ b/batchflow/batch.py
@@ -914,7 +914,7 @@ class Batch:
             a source format, one of None, 'blosc', 'csv', 'hdf5', 'feather'
 
         dst : None or str or tuple of str
-            components to load
+            components to load `src` to
 
         **kwargs :
             other parameters to pass to format-specific loaders

--- a/batchflow/batch.py
+++ b/batchflow/batch.py
@@ -956,7 +956,7 @@ class Batch:
         _ = args
 
         if dst is not None:
-            self.add_components(np.setdiff1d(components, self.components).tolist())
+            self.add_components(np.setdiff1d(dst, self.components).tolist())
 
         if fmt is None:
             self._load_from_source(src=src, dst=dst)

--- a/batchflow/components.py
+++ b/batchflow/components.py
@@ -10,7 +10,7 @@ from .utils import is_iterable
 
 
 class AdvancedDict(dict):
-    """ dict that supports advanced indexing """
+    """ Dict that supports indexing by `list` and `np.ndarray` """
     def __getitem__(self, item):
         if isinstance(item, (list, np.ndarray)):
             d = type(self)()

--- a/examples/tutorials/01_batch_operations.ipynb
+++ b/examples/tutorials/01_batch_operations.ipynb
@@ -195,10 +195,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "batch 0  contains items [8 6 4]\n",
-      "batch 1  contains items [3 2 9]\n",
-      "batch 2  contains items [5 0 7]\n",
-      "batch 3  contains items [5 0 1]\n"
+      "batch 0  contains items [4 6 9]\n",
+      "batch 1  contains items [3 8 5]\n",
+      "batch 2  contains items [0 1 2]\n",
+      "batch 3  contains items [7 5 1]\n"
      ]
     }
    ],
@@ -269,7 +269,7 @@
    "source": [
     "If too many iterations are made, `StopIteration` will be raised.\n",
     "\n",
-    "Check that there are `NUM_ITEMS * 3` iterations (i.e. 3 epochs), but `n_epochs=2`."
+    "Check that there are `NUM_ITEMS * 3` iterations (i.e. 3 epochs) in loop, but `n_epochs=2` is specified inside `next_batch()` call."
    ]
   },
   {
@@ -281,12 +281,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "batch 1 contains items [5 1 4]\n",
-      "batch 2 contains items [3 0 7]\n",
-      "batch 3 contains items [8 6 9]\n",
-      "batch 4 contains items [0 4 5]\n",
-      "batch 5 contains items [6 8 9]\n",
-      "batch 6 contains items [2 3 7]\n",
+      "batch 1 contains items [3 4 0]\n",
+      "batch 2 contains items [9 5 2]\n",
+      "batch 3 contains items [8 1 7]\n",
+      "batch 4 contains items [0 5 1]\n",
+      "batch 5 contains items [2 7 4]\n",
+      "batch 6 contains items [3 9 6]\n",
       "got StopIteration\n"
      ]
     }
@@ -294,7 +294,7 @@
    "source": [
     "for i in range(NUM_ITEMS * 3):\n",
     "    try:\n",
-    "        batch = dataset.next_batch(BATCH_SIZE, shuffle=True, n_iters=6, drop_last=True)\n",
+    "        batch = dataset.next_batch(BATCH_SIZE, shuffle=True, n_epochs=2, drop_last=True)\n",
     "        print(\"batch\", i + 1, \"contains items\", batch.indices)\n",
     "    except StopIteration:\n",
     "        print(\"got StopIteration\")\n",
@@ -340,19 +340,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "batch 1 contains items [4 3 7]\n",
-      "batch 2 contains items [2 5 6 8 1]\n",
-      "batch 3 contains items [5 0 8 2 4]\n",
-      "batch 4 contains items [9 1 6]\n",
-      "batch 5 contains items [8 3 7 4]\n",
-      "batch 6 contains items [6 9 1 2]\n",
-      "batch 7 contains items [4 3 7]\n",
-      "batch 8 contains items [5 9 8 0 6]\n",
-      "batch 9 contains items [7 5 4 2 6]\n",
-      "batch 10 contains items [9 8 0]\n",
-      "batch 11 contains items [2 0 3 8]\n",
-      "batch 12 contains items [4 1 9 6]\n",
-      "batch 13 contains items [6 4 9]\n"
+      "batch 1 contains items [0 6 9]\n",
+      "batch 2 contains items [5 3 4 8 2]\n",
+      "batch 3 contains items [2 0 6 4 9]\n",
+      "batch 4 contains items [3 5 7]\n",
+      "batch 5 contains items [9 1 0 2]\n",
+      "batch 6 contains items [5 3 7 8]\n",
+      "batch 7 contains items [8 2 1]\n",
+      "batch 8 contains items [7 0 5 3 6]\n",
+      "batch 9 contains items [9 4 1 5 8]\n",
+      "batch 10 contains items [7 3 6]\n",
+      "batch 11 contains items [4 5 6 0]\n",
+      "batch 12 contains items [3 9 1 7]\n",
+      "batch 13 contains items [7 5 3]\n"
      ]
     }
    ],
@@ -595,26 +595,26 @@
       "[[  0   1   2]\n",
       " [100 101 102]\n",
       " [200 201 202]]\n",
-      "and labels: [5 4 4]\n",
+      "and labels: [7 9 6]\n",
       "\n",
       "batch 1  contains items [3 4 5]\n",
       "and batch data consists of features:\n",
       "[[300 301 302]\n",
       " [400 401 402]\n",
       " [500 501 502]]\n",
-      "and labels: [3 6 9]\n",
+      "and labels: [7 8 8]\n",
       "\n",
       "batch 2  contains items [6 7 8]\n",
       "and batch data consists of features:\n",
       "[[600 601 602]\n",
       " [700 701 702]\n",
       " [800 801 802]]\n",
-      "and labels: [6 6 5]\n",
+      "and labels: [0 9 4]\n",
       "\n",
       "batch 3  contains items [9]\n",
       "and batch data consists of features:\n",
       "[[900 901 902]]\n",
-      "and labels: [2]\n",
+      "and labels: [9]\n",
       "\n"
      ]
     }
@@ -645,48 +645,48 @@
      "output_type": "stream",
      "text": [
       "Batch 0\n",
-      "item features: [0 1 2]     item label: 5\n",
-      "item features: [100 101 102]     item label: 4\n",
-      "item features: [200 201 202]     item label: 4\n",
+      "item features: [0 1 2]     item label: 7\n",
+      "item features: [100 101 102]     item label: 9\n",
+      "item features: [200 201 202]     item label: 6\n",
       "\n",
       "You can change batch data, even scalars.\n",
       "New batch features:\n",
       " [[1000 1001 1002]\n",
       " [1100 1101 1102]\n",
       " [1200 1201 1202]]\n",
-      "and labels: [105 104 104]\n",
+      "and labels: [107 109 106]\n",
       "\n",
       "Batch 1\n",
-      "item features: [300 301 302]     item label: 3\n",
-      "item features: [400 401 402]     item label: 6\n",
-      "item features: [500 501 502]     item label: 9\n",
+      "item features: [300 301 302]     item label: 7\n",
+      "item features: [400 401 402]     item label: 8\n",
+      "item features: [500 501 502]     item label: 8\n",
       "\n",
       "You can change batch data, even scalars.\n",
       "New batch features:\n",
       " [[1300 1301 1302]\n",
       " [1400 1401 1402]\n",
       " [1500 1501 1502]]\n",
-      "and labels: [103 106 109]\n",
+      "and labels: [107 108 108]\n",
       "\n",
       "Batch 2\n",
-      "item features: [600 601 602]     item label: 6\n",
-      "item features: [700 701 702]     item label: 6\n",
-      "item features: [800 801 802]     item label: 5\n",
+      "item features: [600 601 602]     item label: 0\n",
+      "item features: [700 701 702]     item label: 9\n",
+      "item features: [800 801 802]     item label: 4\n",
       "\n",
       "You can change batch data, even scalars.\n",
       "New batch features:\n",
       " [[1600 1601 1602]\n",
       " [1700 1701 1702]\n",
       " [1800 1801 1802]]\n",
-      "and labels: [106 106 105]\n",
+      "and labels: [100 109 104]\n",
       "\n",
       "Batch 3\n",
-      "item features: [900 901 902]     item label: 2\n",
+      "item features: [900 901 902]     item label: 9\n",
       "\n",
       "You can change batch data, even scalars.\n",
       "New batch features:\n",
       " [[1900 1901 1902]]\n",
-      "and labels: [102]\n",
+      "and labels: [109]\n",
       "\n"
      ]
     }
@@ -810,7 +810,7 @@
     {
      "data": {
       "text/plain": [
-       "(array([0, 9, 7, 6, 5, 1, 3]), array([8, 4, 2]))"
+       "(array([6, 2, 8, 4, 5, 7, 0]), array([3, 1, 9]))"
       ]
      },
      "execution_count": 25,
@@ -862,9 +862,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
All except one are docstrings edits.

The one in code removes `Batch.load()` unnecessary `str->tuple` conversion, since it doesn't really affect `setdiff1d()` behaviour and the following `add_components()` does the same conversion.

This PR was originally aimed at fixing failing `01_batch_operations.ipynb` tutorial, but this fix is omiited now since there was a more complex one proposed. It requires more work and will be applied later.