### PR TITLE
Modify Research.add_logger

### DIFF
--- a/batchflow/research/__init__.py
+++ b/batchflow/research/__init__.py
@@ -1,7 +1,7 @@
 """ Research module. """
 from .domain import KV, Domain, Option, ConfigAlias
 from .distributor import Distributor
-from .logger import Logger, BasicLogger, PrintLogger, TelegramLogger
+from .logger import BaseLogger, FileLogger, PrintLogger, TelegramLogger
 from .workers import Worker, PipelineWorker
 from .named_expr import ResearchNamedExpression, REU, RP, RI, RC, RR, RD, REP, RID
 from .research import Research

--- a/batchflow/research/logger.py
+++ b/batchflow/research/logger.py
@@ -24,10 +24,10 @@ def log_error(exception, path):
     logging.basicConfig(format='%(levelname)-8s [%(asctime)s] %(message)s', filename=filename, level=logging.ERROR)
     logging.info(_get_traceback(exception))
 
-class Logger:
+class BaseLogger:
     """ Basic logging class.
 
-    Logger consists of one or few pairs of functions (info logging and error logging).
+    BaseLogger consists of one or few pairs of functions (info logging and error logging).
     """
     def __init__(self, loggers=None):
         if loggers is None:
@@ -75,23 +75,23 @@ class Logger:
 
     def __add__(self, other):
         # pylint: disable=protected-access
-        if isinstance(other, Logger):
-            return Logger(self._loggers + other._loggers)
+        if isinstance(other, BaseLogger):
+            return BaseLogger(self._loggers + other._loggers)
         raise TypeError("unsupported operand type(s) for +: '{}' and '{}'".format(type(self), type(other)))
 
-class BasicLogger(Logger):
+class FileLogger(BaseLogger):
     """ Basic logging class """
     def __init__(self):
         super().__init__()
         self._loggers = [{'info': log_info, 'error': log_error, 'kwargs': dict(path=RD())}]
 
-class PrintLogger(Logger):
+class PrintLogger(BaseLogger):
     """ Logging by print """
     def __init__(self):
         super().__init__()
         self._loggers = [{'info': print, 'error': print, 'kwargs': dict()}]
 
-class TelegramLogger(Logger):
+class TelegramLogger(BaseLogger):
     """ Telegram Logger """
     def __init__(self, bot_token, chat_id):
         """ Initialize Logger

--- a/batchflow/research/research.py
+++ b/batchflow/research/research.py
@@ -18,7 +18,7 @@ from .distributor import Distributor
 from .workers import PipelineWorker
 from .domain import Domain, Option, ConfigAlias
 from .job import Job
-from .logger import Logger, BasicLogger, PrintLogger, TelegramLogger
+from .logger import BaseLogger, FileLogger, PrintLogger, TelegramLogger
 from .utils import get_metrics
 from .executable import Executable
 from .named_expr import RP
@@ -42,7 +42,7 @@ class Research:
         self.n_reps = None
         self.n_configs = None
         self.repeat_each = None
-        self.logger = BasicLogger()
+        self.logger = FileLogger()
 
         # update parameters for config. None or dict with keys (function, params, cache)
         self._update_config = None
@@ -273,18 +273,19 @@ class Research:
 
     def add_logger(self, logger, **kwargs):
         """ Add custom Logger into Research.
+
         Parameters
         ----------
-        logger : str, Logger class, tuple or list
-            if str, it can be 'basic', 'print' or 'tg'
-            if tuple, pair of str or Logger class and kwargs for them
-            if list then of str, Logger class and tuples of them and kwargs
+        logger : str, BaseLogger class, tuple or list
+            if str, it can be 'file', 'print' or 'tg'
+            if tuple, pair of str or BaseLogger class and kwargs for them
+            if list then of str, BaseLogger class and tuples of them and kwargs
         kwargs :
-            initialization parameters for Logger (if `logger` is str or Logger class)
+            initialization parameters for BaseLogger (if `logger` is str or BaseLogger class)
         """
         loggers = [logger] if not isinstance(logger, list) else logger
 
-        self.logger = Logger()
+        self.logger = BaseLogger()
 
         for item in loggers:
             if not isinstance(item, tuple):
@@ -292,15 +293,15 @@ class Research:
             logger, params = item
 
             if isinstance(logger, str):
-                if logger == 'basic':
-                    self.logger += BasicLogger()
+                if logger == 'file':
+                    self.logger += FileLogger()
                 elif logger == 'print':
                     self.logger += PrintLogger()
                 elif logger == 'tg':
                     self.logger += TelegramLogger(**params)
                 else:
                     raise ValueError('Unknown logger: {}'.format(logger))
-            elif issubclass(logger, Logger):
+            elif issubclass(logger, BaseLogger):
                 self.logger += logger(**params)
             else:
                 raise ValueError('Unknown logger: {}'.format(logger))

--- a/batchflow/research/research.py
+++ b/batchflow/research/research.py
@@ -283,7 +283,7 @@ class Research:
         kwargs :
             initialization parameters for Logger (if `logger` not a list)
         """
-        if not isinstance(logger, list, **kwargs):
+        if not isinstance(logger, list):
             logger = [logger]
 
         self.logger = Logger()

--- a/batchflow/research/research.py
+++ b/batchflow/research/research.py
@@ -275,12 +275,12 @@ class Research:
         """ Add custom Logger into Research.
         Parameters
         ----------
-        logger : str, Logger, tuple or list
+        logger : str, Logger class, tuple or list
             if str, it can be 'basic', 'print' or 'tg'
-            if tuple, pair of str or Logger and kwargs for them
-            if list then of str, Logger and tuples of them and kwargs
+            if tuple, pair of str or Logger class and kwargs for them
+            if list then of str, Logger class and tuples of them and kwargs
         kwargs :
-            initialization parameters for Logger (if `logger` is str or Logger)
+            initialization parameters for Logger (if `logger` is str or Logger class)
         """
         loggers = [logger] if not isinstance(logger, list) else logger
 

--- a/batchflow/research/research.py
+++ b/batchflow/research/research.py
@@ -273,34 +273,36 @@ class Research:
 
     def add_logger(self, logger, **kwargs):
         """ Add custom Logger into Research.
-
         Parameters
         ----------
-        logger : str, tuple, list or Logger
-            if str, it can be 'basic', 'print' or 'tg',
-            if tuple, pair of str and kwargs for initialization
-            if list then list of str or Logger instances.
+        logger : str, Logger, tuple or list
+            if str, it can be 'basic', 'print' or 'tg'
+            if tuple, pair of str or Logger and kwargs for them
+            if list then of str, Logger and tuples of them and kwargs
         kwargs :
-            initialization parameters for Logger (if `logger` not a list)
+            initialization parameters for Logger (if `logger` is str or Logger)
         """
-        if not isinstance(logger, list):
-            logger = [logger]
+        loggers = [logger] if not isinstance(logger, list) else logger
 
         self.logger = Logger()
-        for item in logger:
-            if isinstance(item, str):
-                item = (item, {})
-            if isinstance(item, tuple):
-                if item[0] == 'basic':
+
+        for item in loggers:
+            if not isinstance(item, tuple):
+                item = (item, kwargs)
+            logger, params = item
+
+            if isinstance(logger, str):
+                if logger == 'basic':
                     self.logger += BasicLogger()
-                elif item[0] == 'print':
+                elif logger == 'print':
                     self.logger += PrintLogger()
-                elif item[0] == 'tg':
-                    self.logger += TelegramLogger(**item[1])
+                elif logger == 'tg':
+                    self.logger += TelegramLogger(**params)
                 else:
-                    raise ValueError('Unknown logger: ' + item[0])
+                    raise ValueError('Unknown logger: ' + logger)
             else:
-                self.logger += item
+                self.logger += logger(**params)
+
         return self
 
     def load_results(self, *args, **kwargs):

--- a/batchflow/research/research.py
+++ b/batchflow/research/research.py
@@ -299,9 +299,11 @@ class Research:
                 elif logger == 'tg':
                     self.logger += TelegramLogger(**params)
                 else:
-                    raise ValueError('Unknown logger: ' + logger)
-            else:
+                    raise ValueError('Unknown logger: {}'.format(logger))
+            elif issubclass(logger, Logger):
                 self.logger += logger(**params)
+            else:
+                raise ValueError('Unknown logger: {}'.format(logger))
 
         return self
 


### PR DESCRIPTION
This PR:

- fixes a bug (when function receives non-empty `kwargs`, it crashes due to wrong `isinstance` call);
- generalizes args parsing — following calls are possible now:
  - `add_logger('basic')`
  - `add_logger('tg', token=token, id=id)`
  - `add_logger((CustomLogger, {'arg': value}))`
  - `add_logger(['basic', 'print'])`
  - `add_logger(['basic', ('tg', {'token': token, 'id': id}), (CustomLogger, {'arg': value})])`