### PR TITLE
Fix ModelDirectory.reset

### DIFF
--- a/batchflow/model_dir.py
+++ b/batchflow/model_dir.py
@@ -44,7 +44,7 @@ class ModelDirectory:
 
     def reset(self):
         """ Reset all models """
-        for model in self.models:
+        for model in self.models.values():
             model.reset()
 
     def eval_expr(self, expr, batch=None):


### PR DESCRIPTION
Since models are stored as a dict, iterating through self.models returned keys,
which are of str type. The subsequent application of reset() function to them
naturally caused an error. Iterating through values resolves the problem.