### PR TITLE
TFModel improvements

### DIFF
--- a/batchflow/models/tf/__init__.py
+++ b/batchflow/models/tf/__init__.py
@@ -22,6 +22,7 @@ sys.modules['tensorflow'] = SilentTF()
 
 
 from .base import TFModel
+from .utils import get_shape, get_channels_axis, get_num_channels, get_batch_size, get_spatial_dim, get_spatial_shape
 from .vgg import VGG, VGG16, VGG19, VGG7
 from .linknet import LinkNet
 from .unet import UNet, UNetPP

--- a/batchflow/models/tf/__init__.py
+++ b/batchflow/models/tf/__init__.py
@@ -28,7 +28,9 @@ from .unet import UNet, UNetPP
 from .vnet import VNet
 from .fcn import FCN, FCN32, FCN16, FCN8
 from .resnet import ResNet, ResNet18, ResNet34, ResNet50, ResNet101, ResNet152, \
-                    ResNeXt18, ResNeXt34, ResNeXt50, ResNeXt101, ResNeXt152
+                    ResNeXt18, ResNeXt34, ResNeXt50, ResNeXt101, ResNeXt152, \
+                    SEResNet18, SEResNet34, SEResNet50, SEResNet101, SEResNet152, \
+                    SEResNeXt18, SEResNeXt34, SEResNeXt50, SEResNeXt101, SEResNeXt152
 from .inception_v1 import Inception_v1
 from .inception_v3 import Inception_v3
 from .inception_v4 import Inception_v4

--- a/batchflow/models/tf/__init__.py
+++ b/batchflow/models/tf/__init__.py
@@ -22,7 +22,8 @@ sys.modules['tensorflow'] = SilentTF()
 
 
 from .base import TFModel
-from .utils import get_shape, get_channels_axis, get_num_channels, get_batch_size, get_spatial_dim, get_spatial_shape
+from .utils import get_shape, get_num_dims, get_channels_axis, get_num_channels, \
+                   get_batch_size, get_spatial_dim, get_spatial_shape
 from .vgg import VGG, VGG16, VGG19, VGG7
 from .linknet import LinkNet
 from .unet import UNet, UNetPP

--- a/batchflow/models/tf/base.py
+++ b/batchflow/models/tf/base.py
@@ -13,7 +13,7 @@ from tensorflow.python.client import device_lib
 from ... import Config
 from ..utils import unpack_fn_from_config
 from ..base import BaseModel
-from .layers import mip, conv_block, upsample
+from .layers import mip, conv_block, upsample, ConvBlock
 from .losses import softmax_cross_entropy, dice
 from .nn import piecewise_constant, cyclic_learning_rate
 
@@ -1472,7 +1472,7 @@ class TFModel(BaseModel):
         """
         kwargs = cls.fill_params('initial_block', **kwargs)
         if kwargs.get('layout'):
-            return conv_block(inputs, name=name, **kwargs)
+            return ConvBlock(name=name, **kwargs)(inputs)
         return inputs
 
     @classmethod
@@ -1502,7 +1502,7 @@ class TFModel(BaseModel):
         """
         kwargs = cls.fill_params('body', **kwargs)
         if kwargs.get('layout'):
-            return conv_block(inputs, name=name, **kwargs)
+            return ConvBlock(name=name, **kwargs)(inputs)
         return inputs
 
     @classmethod
@@ -1584,7 +1584,7 @@ class TFModel(BaseModel):
         """
         kwargs = cls.fill_params('head', **kwargs)
         if kwargs.get('layout'):
-            return conv_block(inputs, name=name, **kwargs)
+            return ConvBlock(name=name, **kwargs)(inputs)
         return inputs
 
     def output(self, inputs, predictions=None, ops=None, **kwargs):

--- a/batchflow/models/tf/base.py
+++ b/batchflow/models/tf/base.py
@@ -1398,22 +1398,6 @@ class TFModel(BaseModel):
             return type(name)({key: self._to_graph_items(name[key]) for key in name.keys()})
         raise ValueError('Unrecognized type of value.')
 
-    @classmethod
-    def crop(cls, inputs, resize_to, data_format='channels_last'):
-        """ Crop input tensor to a shape of a given image.
-        If resize_to does not have a fully defined shape (resize_to.get_shape() has at least one None),
-        the returned tf.Tensor will be of unknown shape except the number of channels.
-
-        Parameters
-        ----------
-        inputs : tf.Tensor
-            Input tensor.
-        resize_to : tf.Tensor
-            Tensor which shape the inputs should be resized to.
-        data_format : str {'channels_last', 'channels_first'}
-            Data format.
-        """
-        return Crop(resize_to=resize_to, data_format=data_format)(inputs)
 
     @classmethod
     def initial_block(cls, inputs, name='initial_block', **kwargs):
@@ -1550,6 +1534,7 @@ class TFModel(BaseModel):
         if kwargs.get('layout'):
             return ConvBlock(name=name, **kwargs)(inputs)
         return inputs
+
 
     def output(self, inputs, predictions=None, ops=None, **kwargs):
         """ Add output operations to the model graph, like predicted probabilities or labels, etc.
@@ -2043,11 +2028,28 @@ class TFModel(BaseModel):
         """
         return tensor.get_shape().as_list()[0]
 
-
     @classmethod
     def channels_axis(cls, data_format='channels_last'):
         """ Return the integer channels axis based on string data format. """
         return 1 if data_format == "channels_first" or data_format.startswith("NC") else -1
+
+
+    @classmethod
+    def crop(cls, inputs, resize_to, data_format='channels_last'):
+        """ Crop input tensor to a shape of a given image.
+        If resize_to does not have a fully defined shape (resize_to.get_shape() has at least one None),
+        the returned tf.Tensor will be of unknown shape except the number of channels.
+
+        Parameters
+        ----------
+        inputs : tf.Tensor
+            Input tensor.
+        resize_to : tf.Tensor
+            Tensor which shape the inputs should be resized to.
+        data_format : str {'channels_last', 'channels_first'}
+            Data format.
+        """
+        return Crop(resize_to=resize_to, data_format=data_format)(inputs)
 
     @classmethod
     def se_block(cls, inputs, ratio, name='se', **kwargs):

--- a/batchflow/models/tf/encoder_decoder.py
+++ b/batchflow/models/tf/encoder_decoder.py
@@ -281,7 +281,7 @@ class EncoderDecoder(TFModel):
 
                         for letter in order:
                             if letter == 'b':
-                                x = base_block(x, name='block', **args)
+                                x = conv_block(x, base_block=base_block, name='block', **args)
                             elif letter == 's':
                                 encoder_outputs.append(x)
                             elif letter in ['d', 'p']:
@@ -318,7 +318,7 @@ class EncoderDecoder(TFModel):
         tf.Tensor
         """
         base_block = kwargs.get('base', cls.block)
-        return base_block(inputs, name=name, **kwargs)
+        return conv_block(inputs, base_block=base_block, name=name, **kwargs)
 
     @classmethod
     def decoder(cls, inputs, name='decoder', return_all=False, **kwargs):
@@ -419,7 +419,7 @@ class EncoderDecoder(TFModel):
 
                     for letter in order:
                         if letter == 'b':
-                            x = base_block(x, name='block', **args)
+                            x = conv_block(x, base_block=base_block, name='block', **args)
                         elif letter in ['u']:
                             if upsample.get('layout') is not None:
                                 x = cls.upsample(x, name='upsample', **upsample_args)

--- a/batchflow/models/tf/encoder_decoder.py
+++ b/batchflow/models/tf/encoder_decoder.py
@@ -267,7 +267,6 @@ class EncoderDecoder(TFModel):
             steps, downsample, block_args = cls.pop(['num_stages', 'downsample', 'blocks'], kwargs)
             order = ''.join([item[0] for item in order])
 
-            base_block = block_args.get('base')
             with tf.variable_scope(name):
                 x = inputs
                 encoder_outputs = []
@@ -281,7 +280,7 @@ class EncoderDecoder(TFModel):
 
                         for letter in order:
                             if letter == 'b':
-                                x = ConvBlock(base_block=base_block, name='block', **args)(x)
+                                x = ConvBlock(name='block', **args)(x)
                             elif letter == 's':
                                 encoder_outputs.append(x)
                             elif letter in ['d', 'p']:
@@ -317,8 +316,7 @@ class EncoderDecoder(TFModel):
         -------
         tf.Tensor
         """
-        base_block = kwargs.get('base', cls.block)
-        return ConvBlock(base_block=base_block, name=name, **kwargs)(inputs)
+        return ConvBlock(name=name, **kwargs)(inputs)
 
     @classmethod
     def decoder(cls, inputs, name='decoder', return_all=False, **kwargs):
@@ -387,7 +385,6 @@ class EncoderDecoder(TFModel):
         factor = kwargs.pop('factor') or [2]*steps
         skip, order, upsample, block_args = cls.pop(['skip', 'order', 'upsample', 'blocks'], kwargs)
         order = ''.join([item[0] for item in order])
-        base_block = block_args.get('base')
 
         outputs = []
 
@@ -419,7 +416,7 @@ class EncoderDecoder(TFModel):
 
                     for letter in order:
                         if letter == 'b':
-                            x = ConvBlock(base_block=base_block, name='block', **args)(x)
+                            x = ConvBlock(name='block', **args)(x)
                         elif letter in ['u']:
                             if upsample.get('layout') is not None:
                                 x = cls.upsample(x, name='upsample', **upsample_args)

--- a/batchflow/models/tf/encoder_decoder.py
+++ b/batchflow/models/tf/encoder_decoder.py
@@ -3,7 +3,7 @@
 import tensorflow as tf
 
 from . import TFModel
-from .layers import conv_block, combine
+from .layers import ConvBlock, combine
 from ..utils import unpack_args
 
 
@@ -198,7 +198,7 @@ class EncoderDecoder(TFModel):
             channels = cls.num_channels(targets)
             if cls.num_channels(x) != channels:
                 args = {**kwargs, **dict(layout='c', kernel_size=1, filters=channels, strides=1)}
-                x = conv_block(x, name='conv1x1', **args)
+                x = ConvBlock(name='conv1x1', **args)(x)
 
         return x
 
@@ -210,7 +210,7 @@ class EncoderDecoder(TFModel):
         """
         layout = kwargs.pop('layout', 'cna')
         filters = kwargs.pop('filters', cls.num_channels(inputs))
-        return conv_block(inputs, layout=layout, filters=filters, name=name, **kwargs)
+        return ConvBlock(layout=layout, filters=filters, name=name, **kwargs)(inputs)
 
 
     @classmethod
@@ -281,12 +281,12 @@ class EncoderDecoder(TFModel):
 
                         for letter in order:
                             if letter == 'b':
-                                x = conv_block(x, base_block=base_block, name='block', **args)
+                                x = ConvBlock(base_block=base_block, name='block', **args)(x)
                             elif letter == 's':
                                 encoder_outputs.append(x)
                             elif letter in ['d', 'p']:
                                 if downsample.get('layout') is not None:
-                                    x = conv_block(x, name='downsample', **downsample_args)
+                                    x = ConvBlock(name='downsample', **downsample_args)(x)
                             else:
                                 raise ValueError('Unknown letter in order {}, use one of "b", "d", "p", "s"'
                                                  .format(letter))
@@ -318,7 +318,7 @@ class EncoderDecoder(TFModel):
         tf.Tensor
         """
         base_block = kwargs.get('base', cls.block)
-        return conv_block(inputs, base_block=base_block, name=name, **kwargs)
+        return ConvBlock(base_block=base_block, name=name, **kwargs)(inputs)
 
     @classmethod
     def decoder(cls, inputs, name='decoder', return_all=False, **kwargs):
@@ -419,7 +419,7 @@ class EncoderDecoder(TFModel):
 
                     for letter in order:
                         if letter == 'b':
-                            x = conv_block(x, base_block=base_block, name='block', **args)
+                            x = ConvBlock(base_block=base_block, name='block', **args)(x)
                         elif letter in ['u']:
                             if upsample.get('layout') is not None:
                                 x = cls.upsample(x, name='upsample', **upsample_args)

--- a/batchflow/models/tf/encoder_decoder.py
+++ b/batchflow/models/tf/encoder_decoder.py
@@ -63,10 +63,8 @@ class EncoderDecoder(TFModel):
                 If list, upsampling factors for each stage.
 
             skip : bool, dict
-                If bool, then whether to combine upsampled tensor with stored pre-downsample encoding by
-                using `combine_op`, that can be specified for each of blocks separately.
-                If dict, then parameters for combining upsampled tensor with stored pre-downsample encoding,
-                see :class:`~.tf.layers.Combine`.
+                Whether to combine upsampled tensor with stored pre-downsample encoding by
+                using `combine`, that can be specified for each of blocks separately.
 
             order : str, sequence of str
                 Determines order of applying layers.

--- a/batchflow/models/tf/encoder_decoder.py
+++ b/batchflow/models/tf/encoder_decoder.py
@@ -3,7 +3,7 @@
 import tensorflow as tf
 
 from . import TFModel
-from .layers import ConvBlock, combine
+from .layers import ConvBlock, Combine, Upsample
 from ..utils import unpack_args
 
 
@@ -83,11 +83,29 @@ class EncoderDecoder(TFModel):
 
                 base : callable
                     Tensor processing function. Default is :func:`~.layers.conv_block`.
-                combine_op : str, dict
-                    If str, then operation for combining tensors, see :class:`~.tf.layers.Combine`.
-                    If dict, then parameters for combining tensors, see :class:`~.tf.layers.Combine`.
                 other args : dict
                     Parameters for the base block.
+
+            combine : dict
+                Parameters for combining decoder tensor and skip from encoder:
+
+                    op : str
+                        Which operation to use for combining tensors.
+                        If 'concat', inputs are concated along channels axis.
+                        If one of 'avg', 'mean', takes average of inputs.
+                        If one of 'sum', 'add', inputs are summed.
+                        If one of 'softsum', 'convsum', every tensor is passed through 1x1 convolution in order to have
+                        the same number of channels as the first tensor, and then summed.
+                        If one of 'attention', then the first tensor is used to create multiplicative
+                        attention for second, and the output is added to second tensor.
+                    data_format : str {'channels_last', 'channels_first'}
+                        Data format.
+                    leading_index : int
+                        Index of tensor to broadcast to. Allows to change the order of input tensors.
+                    force_resize : None or bool
+                        Whether to crop every tensor to the leading one.
+                    kwargs : dict
+                        Arguments for :class:`.ConvBlock`.
 
     head : dict, optional
         parameters for the head layers, usually :func:`.conv_block` parameters
@@ -152,6 +170,7 @@ class EncoderDecoder(TFModel):
                                       order=['upsampling', 'block', 'combine'])
         config['body/decoder/upsample'] = dict(layout='tna')
         config['body/decoder/blocks'] = dict(base=cls.block, combine_op='concat')
+        config['body/decoder/combine'] = dict(op='concat', force_resize=None)
         return config
 
     @classmethod
@@ -383,7 +402,8 @@ class EncoderDecoder(TFModel):
         """
         steps = kwargs.pop('num_stages') or len(inputs)-2
         factor = kwargs.pop('factor') or [2]*steps
-        skip, order, upsample, block_args = cls.pop(['skip', 'order', 'upsample', 'blocks'], kwargs)
+        skip, order = cls.pop(['skip', 'order'], kwargs)
+        upsample_args, block_args, combine_args = cls.pop(['upsample', 'blocks', 'combine'], kwargs)
         order = ''.join([item[0] for item in order])
 
         outputs = []
@@ -403,28 +423,19 @@ class EncoderDecoder(TFModel):
                     if factor[i] == 1:
                         continue
 
-                    # Make all the args
-                    args = {**kwargs, **block_args, **unpack_args(block_args, i, steps)}
-                    upsample_args = {'factor': factor[i],
-                                     **kwargs, **upsample, **unpack_args(upsample, i, steps)}
-
-                    combine_op = args.get('combine_op')
-                    combine_args = {'op': combine_op if isinstance(combine_op, str) else '',
-                                    'data_format': args.get('data_format'),
-                                    **(combine_op if isinstance(combine_op, dict) else {}),
-                                    **(skip if isinstance(skip, dict) else {})}
-
                     for letter in order:
                         if letter == 'b':
+                            args = {**kwargs, **block_args, **unpack_args(block_args, i, steps)}
                             x = ConvBlock(name='block', **args)(x)
                         elif letter in ['u']:
-                            if upsample.get('layout') is not None:
-                                x = cls.upsample(x, name='upsample', **upsample_args)
+                            args = {'factor': factor[i],
+                                    **kwargs, **upsample_args, **unpack_args(upsample_args, i, steps)}
+                            x = Upsample(name='upsample', **args)(x)
                         elif letter == 'c':
                             # Combine result with the stored encoding of the ~same shape
-                            if (skip or isinstance(skip, dict)) and (i < len(inputs) - 2):
-                                x = cls.crop(x, inputs[-i - 3], data_format=kwargs.get('data_format'))
-                                x = combine([x, inputs[-i - 3]], **combine_args)
+                            if skip and (i < len(inputs) - 2):
+                                args = {**kwargs, **combine_args, **unpack_args(combine_args, i, steps)}
+                                x = Combine(**args)([x, inputs[-i - 3]])
                         else:
                             raise ValueError('Unknown letter in order {}, use one of ("b", "u", "c")'.format(letter))
                     if return_all:

--- a/batchflow/models/tf/fcn.py
+++ b/batchflow/models/tf/fcn.py
@@ -209,7 +209,7 @@ class FCN16(FCN):
 
             x = cls.upsample(x, factor=2, filters=num_classes, name='fcn32_upsample', **upsample_args, **kwargs)
 
-            skip = conv_block(skip, 'c', filters=num_classes, kernel_size=1, name='pool4', **kwargs)
+            skip = conv_block(skip, layout='c', filters=num_classes, kernel_size=1, name='pool4', **kwargs)
             x = cls.crop(x, skip, kwargs.get('data_format'))
             output = tf.add(x, skip, name='output')
         return output
@@ -287,7 +287,7 @@ class FCN8(FCN):
             x = FCN16.body((x, skip1), filters=filters, num_classes=num_classes, name='fcn16', **kwargs)
             x = cls.upsample(x, factor=2, filters=num_classes, name='fcn16_upsample', **upsample_args, **kwargs)
 
-            skip2 = conv_block(skip2, 'c', num_classes, 1, name='pool3', **kwargs)
+            skip2 = conv_block(skip2, layout='c', filters=num_classes, kernel_size=1, name='pool3', **kwargs)
 
             x = cls.crop(x, skip2, kwargs.get('data_format'))
             output = tf.add(x, skip2, name='output')

--- a/batchflow/models/tf/inception_base.py
+++ b/batchflow/models/tf/inception_base.py
@@ -122,10 +122,12 @@ class Inception(TFModel):
         tf.Tensor
         """
         with tf.variable_scope(name):
-            branch_3 = conv_block(inputs, layout, filters[3], 3, name='conv_3', strides=2, padding='valid', **kwargs)
-            branch_1_3 = conv_block(inputs, layout*2, [filters[0]]+[filters[1]], [1, 3], name='conv_1_3', **kwargs)
-            branch_1_3_3 = conv_block(branch_1_3, layout, filters[2], 3, name='conv_1_3_3', strides=2,
-                                      padding='valid', **kwargs)
+            branch_3 = conv_block(inputs, layout=layout, filters=filters[3], kernel_size=3, strides=2, padding='valid',
+                                  name='conv_3', **kwargs)
+            branch_1_3 = conv_block(inputs, layout=layout*2, filters=[filters[0]]+[filters[1]], kernel_size=[1, 3],
+                                    name='conv_1_3', **kwargs)
+            branch_1_3_3 = conv_block(branch_1_3, layout=layout, filters=filters[2], kernel_size=3, strides=2,
+                                      padding='valid', name='conv_1_3_3', **kwargs)
 
             branch_pool = conv_block(inputs, layout='p', pool_size=3, pool_strides=2, name='max_pooling',
                                      padding='valid', **kwargs)

--- a/batchflow/models/tf/inception_resnet_v2.py
+++ b/batchflow/models/tf/inception_resnet_v2.py
@@ -62,23 +62,28 @@ class InceptionResNet_v2(Inception):
             layout, filters = cls.pop(['layout', 'filters'], kwargs)
             axis = cls.channels_axis(kwargs['data_format'])
 
-            x = conv_block(inputs, layout*2, filters[0]*2, 3, name='conv_3_3', padding='valid',
-                           strides=[2, 1], **kwargs)
-            x = conv_block(x, layout, filters[1], 3, name='conv_3_3_3', **kwargs)
+            x = conv_block(inputs, layout=layout*2, filters=filters[0]*2, kernel_size=3, strides=[2, 1],
+                           padding='valid', name='conv_3_3', **kwargs)
+            x = conv_block(x, layout=layout, filters=filters[1], kernel_size=3,
+                           name='conv_3_3_3', **kwargs)
 
-            branch_3 = conv_block(x, layout, filters[2], 3, name='conv_3', strides=2, padding='valid', **kwargs)
+            branch_3 = conv_block(x, layout=layout, filters=filters[2], kernel_size=3, strides=2,
+                                  padding='valid', name='conv_3', **kwargs)
             branch_pool = conv_block(x, layout='p', name='max_pool', padding='valid', **kwargs)
             x = tf.concat([branch_3, branch_pool], axis, name='concat_3_and_pool')
 
-            branch_1 = conv_block(x, layout, filters[1], 1, name='conv_1', **kwargs)
-            branch_1_3 = conv_block(branch_1, layout, filters[2], 3, name='conv_1_3', padding='valid', **kwargs)
+            branch_1 = conv_block(x, layout=layout, filters=filters[1], kernel_size=1, name='conv_1', **kwargs)
+            branch_1_3 = conv_block(branch_1, layout=layout, filters=filters[2], kernel_size=3, padding='valid',
+                                    name='conv_1_3', **kwargs)
 
-            branch_1_7 = conv_block(x, layout*3, [filters[1]]*3, [1, [7, 1], [1, 7]], name='conv_1_7', **kwargs)
-            branch_1_7_3 = conv_block(branch_1_7, layout, filters[2], 3, name='conv_1_7_3', padding='valid', **kwargs)
+            branch_1_7 = conv_block(x, layout=layout*3, filters=[filters[1]]*3, kernel_size=[1, [7, 1], [1, 7]],
+                                    name='conv_1_7', **kwargs)
+            branch_1_7_3 = conv_block(branch_1_7, layout=layout, filters=filters[2], kernel_size=3,
+                                      padding='valid', name='conv_1_7_3', **kwargs)
             x = tf.concat([branch_1_3, branch_1_7_3], axis, name='concat_1_3_and_1_7_3')
 
-            branch_out_3 = conv_block(x, layout, filters[3], 3, name='conv_out_3', strides=2,
-                                      padding='valid', **kwargs)
+            branch_out_3 = conv_block(x, layout=layout, filters=filters[3], kernel_size=3, strides=2,
+                                      padding='valid', name='conv_out_3', **kwargs)
             branch_out_pool = conv_block(x, layout='p', name='out_max_pooling', padding='valid', **kwargs)
 
             output = tf.concat([branch_out_3, branch_out_pool], axis, name='output')
@@ -149,18 +154,18 @@ class InceptionResNet_v2(Inception):
         with tf.variable_scope(name):
             x = tf.nn.relu(inputs)
 
-            branch_1 = conv_block(x, layout, filters[0], 1, name='conv_1', **kwargs)
-            branch_2 = conv_block(x, layout*2, [filters[1], filters[2]], [1, 3], name='conv_2', **kwargs)
-            branch_3 = conv_block(x, layout*3, [filters[3], filters[4], filters[5]], [1, 3, 3], name='conv_3', **kwargs)
+            branch_1 = conv_block(x, layout=layout, filters=filters[0], kernel_size=1, name='conv_1', **kwargs)
+            branch_2 = conv_block(x, layout=layout*2, filters=[filters[1], filters[2]], kernel_size=[1, 3],
+                                  name='conv_2', **kwargs)
+            branch_3 = conv_block(x, layout=layout*3, filters=[filters[3], filters[4], filters[5]],
+                                  kernel_size=[1, 3, 3], name='conv_3', **kwargs)
 
             axis = cls.channels_axis(kwargs['data_format'])
             branch_1 = tf.concat([branch_1, branch_2, branch_3], axis=axis)
-            branch_1 = conv_block(branch_1, 'c', filters[6], 1, name='conv_1x1', **kwargs)
+            branch_1 = conv_block(branch_1, layout='c', filters=filters[6], kernel_size=1, name='conv_1x1', **kwargs)
 
             x = x + branch_1
-
             x = tf.nn.relu(x)
-
         return x
 
     @classmethod
@@ -185,18 +190,16 @@ class InceptionResNet_v2(Inception):
         with tf.variable_scope(name):
             x = tf.nn.relu(inputs)
 
-            branch_1 = conv_block(x, layout, filters[0], 1, name='conv_1', **kwargs)
-            branch_2 = conv_block(x, layout*3, [filters[1], filters[2], filters[3]], [1, (1, 7), (7, 1)],
-                                  name='conv_2', **kwargs)
+            branch_1 = conv_block(x, layout=layout, filters=filters[0], kernel_size=1, name='conv_1', **kwargs)
+            branch_2 = conv_block(x, layout=layout*3, filters=[filters[1], filters[2], filters[3]],
+                                  kernel_size=[1, (1, 7), (7, 1)], name='conv_2', **kwargs)
 
             axis = cls.channels_axis(kwargs['data_format'])
             branch_1 = tf.concat([branch_1, branch_2], axis=axis)
-            branch_1 = conv_block(branch_1, 'c', filters[4], 1, name='conv_1x1', **kwargs)
+            branch_1 = conv_block(branch_1, layout='c', filters=filters[4], kernel_size=1, name='conv_1x1', **kwargs)
 
             x = x + branch_1
-
             x = tf.nn.relu(x)
-
         return x
 
     @classmethod
@@ -221,18 +224,16 @@ class InceptionResNet_v2(Inception):
         with tf.variable_scope(name):
             x = tf.nn.relu(inputs)
 
-            branch_1 = conv_block(x, layout, filters[0], 1, name='conv_1', **kwargs)
-            branch_2 = conv_block(x, layout*3, [filters[1], filters[2], filters[3]], [1, (1, 3), (3, 1)],
-                                  name='conv_2', **kwargs)
+            branch_1 = conv_block(x, layout=layout, filters=filters[0], kernel_size=1, name='conv_1', **kwargs)
+            branch_2 = conv_block(x, layout=layout*3, filters=[filters[1], filters[2], filters[3]],
+                                  kernel_size=[1, (1, 3), (3, 1)], name='conv_2', **kwargs)
 
             axis = cls.channels_axis(kwargs['data_format'])
             branch_1 = tf.concat([branch_1, branch_2], axis=axis)
-            branch_1 = conv_block(branch_1, 'c', filters[4], 1, name='conv_1x1', **kwargs)
+            branch_1 = conv_block(branch_1, layout='c', filters=filters[4], kernel_size=1, name='conv_1x1', **kwargs)
 
             x = x + branch_1
-
             x = tf.nn.relu(x)
-
         return x
 
     @classmethod
@@ -257,10 +258,11 @@ class InceptionResNet_v2(Inception):
         with tf.variable_scope(name):
             x = tf.nn.relu(inputs)
 
-            branch_1 = conv_block(x, 'p', pool_strides=2, name='max-pool', **kwargs)
-            branch_2 = conv_block(x, layout, filters[0], 3, strides=2, name='conv_2', **kwargs)
-            branch_3 = conv_block(x, layout*3, [filters[1], filters[2], filters[3]], [1, 3, 3],
-                                  strides=[1, 1, 2], name='conv_3', **kwargs)
+            branch_1 = conv_block(x, layout='p', pool_strides=2, name='max-pool', **kwargs)
+            branch_2 = conv_block(x, layout=layout, filters=filters[0], kernel_size=3, strides=2,
+                                  name='conv_2', **kwargs)
+            branch_3 = conv_block(x, layout=layout*3, filters=[filters[1], filters[2], filters[3]],
+                                  kernel_size=[1, 3, 3], strides=[1, 1, 2], name='conv_3', **kwargs)
 
             axis = cls.channels_axis(kwargs['data_format'])
             x = tf.concat([branch_1, branch_2, branch_3], axis=axis)
@@ -289,12 +291,12 @@ class InceptionResNet_v2(Inception):
         with tf.variable_scope(name):
             x = inputs
             branch_1 = conv_block(x, 'p', pool_size=3, pool_strides=2, name='max-pool', **kwargs)
-            branch_2 = conv_block(x, layout*2, [filters[0], filters[1]], [1, 3], strides=[1, 2],
-                                  name='conv_2', **kwargs)
-            branch_3 = conv_block(x, layout*2, [filters[2], filters[3]], [1, 3], strides=[1, 2],
-                                  name='conv_3', **kwargs)
-            branch_4 = conv_block(x, layout*3, [filters[4], filters[5], filters[6]], [1, 3, 3], strides=[1, 1, 2],
-                                  name='conv_4', **kwargs)
+            branch_2 = conv_block(x, layout=layout*2, filters=[filters[0], filters[1]], kernel_size=[1, 3],
+                                  strides=[1, 2], name='conv_2', **kwargs)
+            branch_3 = conv_block(x, layout=layout*2, filters=[filters[2], filters[3]], kernel_size=[1, 3],
+                                  strides=[1, 2], name='conv_3', **kwargs)
+            branch_4 = conv_block(x, layout=layout*3, filters=[filters[4], filters[5], filters[6]],
+                                  kernel_size=[1, 3, 3], strides=[1, 1, 2], name='conv_4', **kwargs)
 
             axis = cls.channels_axis(kwargs['data_format'])
             x = tf.concat([branch_1, branch_2, branch_3, branch_4], axis)

--- a/batchflow/models/tf/inception_v1.py
+++ b/batchflow/models/tf/inception_v1.py
@@ -72,13 +72,15 @@ class Inception_v1(Inception):
         tf.Tensor
         """
         with tf.variable_scope(name):
-            branch_1 = conv_block(inputs, layout, filters[0], 1, name='conv_1', **kwargs)
+            branch_1 = conv_block(inputs, layout=layout, filters=filters[0], kernel_size=1, name='conv_1', **kwargs)
 
-            branch_3 = conv_block(inputs, layout*2, [filters[1], filters[2]], [1, 3], name='conv_3', **kwargs)
+            branch_3 = conv_block(inputs, layout=layout*2, filters=[filters[1], filters[2]], kernel_size=[1, 3],
+                                  name='conv_3', **kwargs)
 
-            branch_5 = conv_block(inputs, layout*2, [filters[3], filters[4]], [1, 5], name='conv_5', **kwargs)
+            branch_5 = conv_block(inputs, layout=layout*2, filters=[filters[3], filters[4]], kernel_size=[1, 5],
+                                  name='conv_5', **kwargs)
 
-            branch_pool = conv_block(inputs, 'p'+layout, filters[5], 1,
+            branch_pool = conv_block(inputs, layout='p'+layout, filters=filters[5], kernel_size=1,
                                      name='conv_pool', **{**kwargs, 'pool_strides': 1})
 
             axis = cls.channels_axis(kwargs['data_format'])
@@ -102,5 +104,5 @@ class Inception_v1(Inception):
         -------
         tf.Tensor
         """
-        output = conv_block(inputs, layout, filters=filters, name=name, **kwargs)
+        output = conv_block(inputs, layout=layout, filters=filters, name=name, **kwargs)
         return output

--- a/batchflow/models/tf/inception_v3.py
+++ b/batchflow/models/tf/inception_v3.py
@@ -72,14 +72,16 @@ class Inception_v3(Inception):
         tf.Tensor
         """
         with tf.variable_scope(name):
-            branch_1 = conv_block(inputs, layout, filters[0], 1, name='conv_1', **kwargs)
+            branch_1 = conv_block(inputs, layout=layout, filters=filters[0], kernel_size=1, name='conv_1', **kwargs)
 
-            branch_1_3 = conv_block(inputs, layout*2, [filters[1], filters[0]], [1, 5], name='conv_1_3', **kwargs)
+            branch_1_3 = conv_block(inputs, layout=layout*2, filters=[filters[1], filters[0]], kernel_size=[1, 5],
+                                    name='conv_1_3', **kwargs)
 
-            branch_1_3_3 = conv_block(inputs, layout*3, [filters[0]]+[filters[2]]*2, [1, 3, 3], name='conv_1_3_3',
-                                      **kwargs)
+            branch_1_3_3 = conv_block(inputs, layout=layout*3, filters=[filters[0]]+[filters[2]]*2,
+                                      kernel_size=[1, 3, 3], name='conv_1_3_3', **kwargs)
 
-            branch_pool = conv_block(inputs, 'p'+layout, filters[3], 1, name='c_pool', **{**kwargs, 'pool_strides': 1})
+            branch_pool = conv_block(inputs, layout='p'+layout, filters=filters[3], kernel_size=1,
+                                     name='c_pool', **{**kwargs, 'pool_strides': 1})
 
             axis = cls.channels_axis(kwargs['data_format'])
             output = tf.concat([branch_1, branch_1_3, branch_1_3_3, branch_pool], axis=axis, name='output')
@@ -106,13 +108,14 @@ class Inception_v3(Inception):
         tf.Tensor
         """
         with tf.variable_scope(name):
-            branch_1 = conv_block(inputs, layout, filters[0], 1, name='conv_1', **kwargs)
-            branch_1_3 = conv_block(branch_1, layout, filters[1], 3, name='conv_1_3', strides=2,
-                                    padding='valid', **kwargs)
+            branch_1 = conv_block(inputs, layout=layout, filters=filters[0], kernel_size=1, name='conv_1', **kwargs)
+            branch_1_3 = conv_block(branch_1, layout=layout, filters=filters[1], kernel_size=3, strides=2,
+                                    padding='valid', name='conv_1_3', **kwargs)
 
-            branch_1_7 = conv_block(inputs, layout*3, filters[0], [1, (1, 7), (7, 1)], name='conv_1_7', **kwargs)
-            branch_1_7_3 = conv_block(branch_1_7, layout, filters[0], 3, name='conv_1_7_3', strides=2,
-                                      padding='valid', **kwargs)
+            branch_1_7 = conv_block(inputs, layout=layout*3, filters=filters[0], kernel_size=[1, (1, 7), (7, 1)],
+                                    name='conv_1_7', **kwargs)
+            branch_1_7_3 = conv_block(branch_1_7, layout=layout, filters=filters[0], kernel_size=3, strides=2,
+                                      padding='valid', name='conv_1_7_3', **kwargs)
 
             branch_pool = conv_block(inputs, layout='p', name='c_pool', padding='valid', pool_size=3,
                                      pool_strides=2, **kwargs)
@@ -141,18 +144,19 @@ class Inception_v3(Inception):
         tf.Tensor
         """
         with tf.variable_scope(name):
-            branch_1 = conv_block(inputs, layout, filters[0], 1, name='conv_1', **kwargs)
+            branch_1 = conv_block(inputs, layout=layout, filters=filters[0], kernel_size=1, name='conv_1', **kwargs)
 
             factor = [1, 7], [7, 1]
             kernel_size = [1, *factor]
-            branch_1_3 = conv_block(inputs, layout * 3, [filters[1]] * 2 + [filters[0]], kernel_size,
-                                    name='conv_1_3', **kwargs)
+            branch_1_3 = conv_block(inputs, layout=layout * 3, filters=[filters[1]] * 2 + [filters[0]],
+                                    kernel_size=kernel_size, name='conv_1_3', **kwargs)
 
             kernel_size = [1, *factor[::-1] * 2]
-            branch_1_7 = conv_block(inputs, layout * 5, [filters[1]] * 4 + [filters[0]], kernel_size,
-                                    name='conv_1_7', **kwargs)
+            branch_1_7 = conv_block(inputs, layout=layout * 5, filters=[filters[1]] * 4 + [filters[0]],
+                                    kernel_size=kernel_size, name='conv_1_7', **kwargs)
 
-            branch_pool = conv_block(inputs, 'p'+layout, filters[0], 1, name='c_pool', **{**kwargs, 'pool_strides': 1})
+            branch_pool = conv_block(inputs, layout='p'+layout, filters=filters[0], kernel_size=1,
+                                     name='c_pool', **{**kwargs, 'pool_strides': 1})
 
             axis = cls.channels_axis(kwargs['data_format'])
             output = tf.concat([branch_1, branch_1_3, branch_1_7, branch_pool], axis=axis, name='output')
@@ -179,19 +183,24 @@ class Inception_v3(Inception):
         """
         with tf.variable_scope(name):
             axis = cls.channels_axis(kwargs['data_format'])
-            branch_1 = conv_block(inputs, layout, filters[0], 1, name='conv_1', **kwargs)
+            branch_1 = conv_block(inputs, layout=layout, filters=filters[0], kernel_size=1, name='conv_1', **kwargs)
 
-            branch_pool = conv_block(inputs, 'p'+layout, filters[3], 1, name='c_pool',
+            branch_pool = conv_block(inputs, layout='p'+layout, filters=filters[3], kernel_size=1, name='c_pool',
                                      **{**kwargs, 'pool_strides': 1})
 
-            branch_a1 = conv_block(inputs, layout, filters[1], 1, name='conv_a1', **kwargs)
-            branch_a1_31 = conv_block(branch_a1, layout, filters[1], [3, 1], name='conv_1_31', **kwargs)
-            branch_a1_13 = conv_block(branch_a1, layout, filters[1], [1, 3], name='conv_1_13', **kwargs)
+            branch_a1 = conv_block(inputs, layout=layout, filters=filters[1], kernel_size=1, name='conv_a1', **kwargs)
+            branch_a1_31 = conv_block(branch_a1, layout=layout, filters=filters[1], kernel_size=[3, 1],
+                                      name='conv_1_31', **kwargs)
+            branch_a1_13 = conv_block(branch_a1, layout=layout, filters=filters[1], kernel_size=[1, 3],
+                                      name='conv_1_13', **kwargs)
             branch_a = tf.concat([branch_a1_31, branch_a1_13], axis=axis)
 
-            branch_b13 = conv_block(inputs, layout*2, [filters[2], filters[1]], [1, 3], name='conv_b13', **kwargs)
-            branch_b13_31 = conv_block(branch_b13, layout, filters[1], [3, 1], name='conv_b13_31', **kwargs)
-            branch_b13_13 = conv_block(branch_b13, layout, filters[1], [1, 3], name='conv_b13_13', **kwargs)
+            branch_b13 = conv_block(inputs, layout=layout*2, filters=[filters[2], filters[1]], kernel_size=[1, 3],
+                                    name='conv_b13', **kwargs)
+            branch_b13_31 = conv_block(branch_b13, layout=layout, filters=filters[1], kernel_size=[3, 1],
+                                       name='conv_b13_31', **kwargs)
+            branch_b13_13 = conv_block(branch_b13, layout=layout, filters=filters[1], kernel_size=[1, 3],
+                                       name='conv_b13_13', **kwargs)
             branch_b = tf.concat([branch_b13_31, branch_b13_13], axis=axis)
 
             output = tf.concat([branch_1, branch_pool, branch_a, branch_b], axis=axis, name='output')

--- a/batchflow/models/tf/inception_v4.py
+++ b/batchflow/models/tf/inception_v4.py
@@ -64,23 +64,27 @@ class Inception_v4(Inception):
             layout, filters = cls.pop(['layout', 'filters'], kwargs)
             axis = cls.channels_axis(kwargs['data_format'])
 
-            x = conv_block(inputs, layout*2, filters[0]*2, 3, name='conv_3_3', padding='valid',
-                           strides=[2, 1], **kwargs)
-            x = conv_block(x, layout, filters[1], 3, name='conv_3_3_3', **kwargs)
+            x = conv_block(inputs, layout=layout*2, filters=filters[0]*2, kernel_size=3, strides=[2, 1],
+                           name='conv_3_3', padding='valid', **kwargs)
+            x = conv_block(x, layout=layout, filters=filters[1], kernel_size=3, name='conv_3_3_3', **kwargs)
 
-            branch_3 = conv_block(x, layout, filters[2], 3, name='conv_3', strides=2, padding='valid', **kwargs)
+            branch_3 = conv_block(x, layout=layout, filters=filters[2], kernel_size=3, strides=2,
+                                  padding='valid', name='conv_3', **kwargs)
             branch_pool = conv_block(x, layout='p', name='max_pool', padding='valid', **kwargs)
             x = tf.concat([branch_3, branch_pool], axis, name='concat_3_and_pool')
 
-            branch_1 = conv_block(x, layout, filters[1], 1, name='conv_1', **kwargs)
-            branch_1_3 = conv_block(branch_1, layout, filters[2], 3, name='conv_1_3', padding='valid', **kwargs)
+            branch_1 = conv_block(x, layout=layout, filters=filters[1], kernel_size=1, name='conv_1', **kwargs)
+            branch_1_3 = conv_block(branch_1, layout=layout, filters=filters[2], kernel_size=3,
+                                    padding='valid', name='conv_1_3', **kwargs)
 
-            branch_1_7 = conv_block(x, layout*3, [filters[1]]*3, [1, [7, 1], [1, 7]], name='conv_1_7', **kwargs)
-            branch_1_7_3 = conv_block(branch_1_7, layout, filters[2], 3, name='conv_1_7_3', padding='valid', **kwargs)
+            branch_1_7 = conv_block(x, layout=layout*3, filters=[filters[1]]*3, kernel_size=[1, [7, 1], [1, 7]],
+                                    name='conv_1_7', **kwargs)
+            branch_1_7_3 = conv_block(branch_1_7, layout=layout, filters=filters[2], kernel_size=3,
+                                      padding='valid', name='conv_1_7_3', **kwargs)
             x = tf.concat([branch_1_3, branch_1_7_3], axis, name='concat_1_3_and_1_7_3')
 
-            branch_out_3 = conv_block(x, layout, filters[3], 3, name='conv_out_3', strides=2,
-                                      padding='valid', **kwargs)
+            branch_out_3 = conv_block(x, layout=layout, filters=filters[3], kernel_size=3, strides=2,
+                                      padding='valid', name='conv_out_3', **kwargs)
             branch_out_pool = conv_block(x, layout='p', name='out_max_pooling', padding='valid', **kwargs)
 
             output = tf.concat([branch_out_3, branch_out_pool], axis, name='output')
@@ -106,14 +110,16 @@ class Inception_v4(Inception):
         tf.Tensor
         """
         with tf.variable_scope(name):
-            branch_1 = conv_block(inputs, layout, filters[0], 1, name='conv_1', **kwargs)
+            branch_1 = conv_block(inputs, layout=layout, filters=filters[0], kernel_size=1, name='conv_1', **kwargs)
 
-            branch_1_3 = conv_block(inputs, layout*2, [filters[1], filters[0]], [1, 3], name='conv_1_3', **kwargs)
+            branch_1_3 = conv_block(inputs, layout=layout*2, filters=[filters[1], filters[0]], kernel_size=[1, 3],
+                                    name='conv_1_3', **kwargs)
 
-            branch_1_3_3 = conv_block(inputs, layout*3, [filters[1]]+[filters[0]]*2, [1, 3, 3], name='conv_1_3_3',
-                                      **kwargs)
+            branch_1_3_3 = conv_block(inputs, layout=layout*3, filters=[filters[1]]+[filters[0]]*2,
+                                      kernel_size=[1, 3, 3], name='conv_1_3_3', **kwargs)
 
-            branch_pool = conv_block(inputs, 'v'+layout, filters[0], 1, name='c_pool', **{**kwargs, 'pool_strides': 1})
+            branch_pool = conv_block(inputs, layout='v'+layout, filters=filters[0], kernel_size=1,
+                                     name='c_pool', **{**kwargs, 'pool_strides': 1})
 
             axis = cls.channels_axis(kwargs['data_format'])
             output = tf.concat([branch_1, branch_1_3, branch_1_3_3, branch_pool], axis, name='output')
@@ -139,18 +145,19 @@ class Inception_v4(Inception):
         tf.Tensor
         """
         with tf.variable_scope(name):
-            branch_1 = conv_block(inputs, layout, filters[0], 1, name='conv_1_3', **kwargs)
+            branch_1 = conv_block(inputs, layout=layout, filters=filters[0], kernel_size=1, name='conv_1_3', **kwargs)
 
             factor = [[1, 7], [7, 1]]
             kernel_size = [1, *factor]
-            branch_1_7 = conv_block(inputs, layout*3, [filters[1], filters[2], filters[3]], kernel_size,
-                                    name='conv_1_7', **kwargs)
+            branch_1_7 = conv_block(inputs, layout=layout*3, filters=[filters[1], filters[2], filters[3]],
+                                    kernel_size=kernel_size, name='conv_1_7', **kwargs)
 
             kernel_size = [1, *factor*2]
-            branch_1_7_7 = conv_block(inputs, layout*5, [filters[1]]*2+[filters[2]]*2+[filters[3]], kernel_size,
-                                      name='conv_1_7_7', **kwargs)
+            branch_1_7_7 = conv_block(inputs, layout=layout*5, filters=[filters[1]]*2+[filters[2]]*2+[filters[3]],
+                                      kernel_size=kernel_size, name='conv_1_7_7', **kwargs)
 
-            branch_pool = conv_block(inputs, 'v'+layout, filters[4], 1, name='c_pool', **{**kwargs, 'pool_strides': 1})
+            branch_pool = conv_block(inputs, layout='v'+layout, filters=filters[4], kernel_size=1,
+                                     name='c_pool', **{**kwargs, 'pool_strides': 1})
 
             axis = cls.channels_axis(kwargs['data_format'])
             output = tf.concat([branch_1, branch_1_7, branch_1_7_7, branch_pool], axis, name='output')
@@ -176,14 +183,14 @@ class Inception_v4(Inception):
         tf.Tensor
         """
         with tf.variable_scope(name):
-            branch_1 = conv_block(inputs, layout, filters[0], 1, name='conv_1', **kwargs)
-            branch_1_3 = conv_block(branch_1, layout, filters[0], 3, name='conv_1_3', strides=2,
-                                    padding='valid', **kwargs)
+            branch_1 = conv_block(inputs, layout=layout, filters=filters[0], kernel_size=1, name='conv_1', **kwargs)
+            branch_1_3 = conv_block(branch_1, layout=layout, filters=filters[0], kernel_size=3, strides=2,
+                                    padding='valid', name='conv_1_3', **kwargs)
 
-            branch_1_7 = conv_block(inputs, layout*3, [filters[1]]*2+[filters[2]], [1, [1, 7], [7, 1]],
-                                    name='conv_1_7', **kwargs)
-            branch_1_7_3 = conv_block(branch_1_7, layout, filters[2], 3, name='conv_1_7_3', strides=2,
-                                      padding='valid', **kwargs)
+            branch_1_7 = conv_block(inputs, layout=layout*3, filters=[filters[1]]*2+[filters[2]],
+                                    kernel_size=[1, [1, 7], [7, 1]], name='conv_1_7', **kwargs)
+            branch_1_7_3 = conv_block(branch_1_7, layout=layout, filters=filters[2], kernel_size=3, strides=2,
+                                      padding='valid', name='conv_1_7_3', **kwargs)
 
             branch_pool = conv_block(inputs, layout='p', name='max_pooling', pool_size=3, pool_strides=2,
                                      padding='valid', **kwargs)
@@ -213,20 +220,25 @@ class Inception_v4(Inception):
         """
         with tf.variable_scope(name):
             axis = cls.channels_axis(kwargs['data_format'])
-            branch_1 = conv_block(inputs, layout, filters[0], 1, name='conv_1', **kwargs)
+            branch_1 = conv_block(inputs, layout=layout, filters=filters[0], kernel_size=1, name='conv_1', **kwargs)
 
-            branch_1 = conv_block(inputs, layout, filters[1], 1, name='conv_1_3', **kwargs)
-            branch_1_13 = conv_block(branch_1, layout, filters[0], [1, 3], name='conv_1_13', **kwargs)
-            branch_1_31 = conv_block(branch_1, layout, filters[0], [3, 1], name='conv_1_31', **kwargs)
+            branch_1 = conv_block(inputs, layout=layout, filters=filters[1], kernel_size=1, name='conv_1_3', **kwargs)
+            branch_1_13 = conv_block(branch_1, layout=layout, filters=filters[0], kernel_size=[1, 3],
+                                     name='conv_1_13', **kwargs)
+            branch_1_31 = conv_block(branch_1, layout=layout, filters=filters[0], kernel_size=[3, 1],
+                                     name='conv_1_31', **kwargs)
             branch_1_33 = tf.concat([branch_1_13, branch_1_31], axis)
 
-            branch_1_13_31 = conv_block(inputs, layout*3, [filters[1], filters[2], filters[3]], [1, [1, 3], [3, 1]],
-                                        name='conv_1_13_31', **kwargs)
-            branch_1_3_13 = conv_block(branch_1_13_31, layout, filters[0], [1, 3], name='conv_1_3_13', **kwargs)
-            branch_1_3_31 = conv_block(branch_1_13_31, layout, filters[0], [3, 1], name='conv_1_3_31', **kwargs)
+            branch_1_13_31 = conv_block(inputs, layout=layout*3, filters=[filters[1], filters[2], filters[3]],
+                                        kernel_size=[1, [1, 3], [3, 1]], name='conv_1_13_31', **kwargs)
+            branch_1_3_13 = conv_block(branch_1_13_31, layout=layout, filters=filters[0], kernel_size=[1, 3],
+                                       name='conv_1_3_13', **kwargs)
+            branch_1_3_31 = conv_block(branch_1_13_31, layout=layout, filters=filters[0], kernel_size=[3, 1],
+                                       name='conv_1_3_31', **kwargs)
             branch_1_5 = tf.concat([branch_1_3_13, branch_1_3_31], axis)
 
-            branch_pool = conv_block(inputs, 'v'+layout, filters[0], 1, name='c_pool', **{**kwargs, 'pool_strides': 1})
+            branch_pool = conv_block(inputs, layout='v'+layout, filters=filters[0], kernel_size=1,
+                                     name='c_pool', **{**kwargs, 'pool_strides': 1})
 
             output = tf.concat([branch_1, branch_1_33, branch_1_5, branch_pool], axis, name='output')
         return output

--- a/batchflow/models/tf/layers/__init__.py
+++ b/batchflow/models/tf/layers/__init__.py
@@ -16,8 +16,9 @@ from .pooling import MaxPooling, AveragePooling, Pooling, \
                      GlobalPooling, GlobalAveragePooling, GlobalMaxPooling, \
                      FractionalPooling
 from .roi import roi_pooling_layer, non_max_suppression
-from .resize import subpixel_conv, resize_bilinear_additive, resize_nn, resize_bilinear, depth_to_space
-from .resize import SubpixelConv, ResizeBilinearAdditive, ResizeNn, ResizeBilinear, DepthToSpace
+from .resize import subpixel_conv, resize_bilinear_additive, resize_nn, resize_bilinear, depth_to_space, \
+					SubpixelConv, ResizeBilinearAdditive, ResizeNn, ResizeBilinear, DepthToSpace, \
+					IncreaseDim, Reshape
 from .pyramid import pyramid_pooling, aspp
 from .drop_block import dropblock
 from .drop_block import Dropblock

--- a/batchflow/models/tf/layers/__init__.py
+++ b/batchflow/models/tf/layers/__init__.py
@@ -17,7 +17,7 @@ from .pooling import MaxPooling, AveragePooling, Pooling, \
 from .roi import roi_pooling_layer, non_max_suppression
 from .resize import subpixel_conv, resize_bilinear_additive, resize_nn, resize_bilinear, depth_to_space, \
 					SubpixelConv, ResizeBilinearAdditive, ResizeNn, ResizeBilinear, DepthToSpace, \
-					IncreaseDim, Reshape, upsample, Upsample
+					IncreaseDim, Reshape, upsample, Upsample, Crop
 from .pyramid import pyramid_pooling, aspp
 from .drop_block import dropblock
 from .drop_block import Dropblock

--- a/batchflow/models/tf/layers/__init__.py
+++ b/batchflow/models/tf/layers/__init__.py
@@ -3,8 +3,8 @@
 from .layer import Layer
 from .conv_block import conv_block, upsample
 from .conv_block import ConvBlock, Upsample
-from .core import flatten, flatten2d, maxout, mip, xip, combine
-from .core import Flatten, Flatten2D, Maxout, Mip, Xip, Combine
+from .core import flatten, flatten2d, activation, dense, maxout, mip, xip, combine
+from .core import Flatten, Flatten2D, Activation, Dense, Dropout, AlphaDropout, Maxout, Mip, Xip, Combine
 from .conv import conv1d_transpose, conv1d_transpose_nn, conv_transpose, \
 				  separable_conv, separable_conv_transpose, depthwise_conv, depthwise_conv_transpose
 from .conv import Conv1DTranspose, Conv1DTransposeNn, ConvTranspose, \

--- a/batchflow/models/tf/layers/__init__.py
+++ b/batchflow/models/tf/layers/__init__.py
@@ -1,8 +1,7 @@
 """ Custom tf layers and operations """
 #pylint: disable=no-name-in-module
 from .layer import Layer
-from .conv_block import conv_block, upsample
-from .conv_block import ConvBlock, Upsample
+from .conv_block import conv_block, ConvBlock, update_layers
 from .core import flatten, flatten2d, activation, dense, maxout, mip, xip, combine
 from .core import Flatten, Flatten2D, Activation, Dense, Dropout, AlphaDropout, Maxout, Mip, Xip, Combine
 from .conv import conv1d_transpose, conv1d_transpose_nn, conv_transpose, \
@@ -18,7 +17,7 @@ from .pooling import MaxPooling, AveragePooling, Pooling, \
 from .roi import roi_pooling_layer, non_max_suppression
 from .resize import subpixel_conv, resize_bilinear_additive, resize_nn, resize_bilinear, depth_to_space, \
 					SubpixelConv, ResizeBilinearAdditive, ResizeNn, ResizeBilinear, DepthToSpace, \
-					IncreaseDim, Reshape
+					IncreaseDim, Reshape, upsample, Upsample
 from .pyramid import pyramid_pooling, aspp
 from .drop_block import dropblock
 from .drop_block import Dropblock

--- a/batchflow/models/tf/layers/conv.py
+++ b/batchflow/models/tf/layers/conv.py
@@ -10,6 +10,7 @@ from .layer import Layer, add_as_function
 @add_as_function
 class Conv(Layer):
     """ Nd convolution layer. Just a wrapper around TensorFlow layers for corresponding dimensions.
+    Used for `c` letter in layout convention of :class:`~.tf.layers.ConvBlock`.
 
     See also
     --------
@@ -107,6 +108,7 @@ class Conv1DTransposeNn:
 @add_as_function
 class ConvTranspose(Layer):
     """ Transposed Nd convolution layer.
+    Used for `C` letter in layout convention of :class:`~.tf.layers.ConvBlock`.
 
     Parameters
     ----------
@@ -209,6 +211,7 @@ class DepthwiseConvND:
 @add_as_function
 class DepthwiseConv(Layer):
     """ Make Nd depthwise convolutions that act separately on channels.
+    Used for `w` letter in layout convention of :class:`~.tf.layers.ConvBlock`.
 
     Parameters
     ----------
@@ -251,6 +254,7 @@ class DepthwiseConv(Layer):
 @add_as_function
 class DepthwiseConvTranspose(Layer):
     """ Make Nd depthwise transpose convolutions that act separately on channels.
+    Used for `W` letter in layout convention of :class:`~.tf.layers.ConvBlock`.
 
     Parameters
     ----------
@@ -348,6 +352,7 @@ class SeparableConvND:
 class SeparableConv(Layer):
     """ Make Nd depthwise convolutions that acts separately on channels,
     followed by a pointwise convolution that mixes channels.
+    Used for `C` letter in layout convention of :class:`~.tf.layers.ConvBlock`.
 
     Parameters
     ----------
@@ -399,6 +404,7 @@ class SeparableConv(Layer):
 class SeparableConvTranspose(Layer):
     """ Make Nd depthwise transpose convolutions that acts separately on channels,
     followed by a pointwise convolution that mixes channels.
+    Used for `T` letter in layout convention of :class:`~.tf.layers.ConvBlock`.
 
     Parameters
     ----------

--- a/batchflow/models/tf/layers/conv.py
+++ b/batchflow/models/tf/layers/conv.py
@@ -108,7 +108,7 @@ class Conv1DTransposeNn:
 @add_as_function
 class ConvTranspose(Layer):
     """ Transposed Nd convolution layer.
-    Used for `C` letter in layout convention of :class:`~.tf.layers.ConvBlock`.
+    Used for `t` letter in layout convention of :class:`~.tf.layers.ConvBlock`.
 
     Parameters
     ----------

--- a/batchflow/models/tf/layers/conv_block.py
+++ b/batchflow/models/tf/layers/conv_block.py
@@ -404,7 +404,8 @@ class BaseConvBlock:
         else:
             layer_params = inspect.getfullargspec(layer_class.__init__)[0]
             layer_params.remove('self')
-            layer_params.remove('name')
+            if 'name' in layer_params:
+                layer_params.remove('name')
 
         args = {param: getattr(self, param, self.kwargs.get(param, None))
                 for param in layer_params

--- a/batchflow/models/tf/layers/conv_block.py
+++ b/batchflow/models/tf/layers/conv_block.py
@@ -11,6 +11,7 @@ from .pooling import Pooling, GlobalPooling
 from .drop_block import Dropblock
 from .resize import ResizeBilinearAdditive, ResizeBilinear, ResizeNn, SubpixelConv
 from .layer import add_as_function, Layer
+from ..utils import get_num_channels, get_spatial_dim, get_channels_axis
 from ...utils import unpack_args
 from .... import Config
 

--- a/batchflow/models/tf/layers/conv_block.py
+++ b/batchflow/models/tf/layers/conv_block.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 class Branch:
+    """ Add side branch to a :class:`~.layers.ConvBlock`. """
     def __init__(self, *args, name='branch', **kwargs):
         self.name = name
         self.args, self.kwargs = args, kwargs
@@ -500,7 +501,7 @@ class ConvBlock:
 
     layer = ConvBlock({layout='cnap', filters='same*2'}, inputs=inputs, n_repeats=5)
     """
-    def __init__(self, *args, inputs=None, base_block=BaseConvBlock, n_repeats=1, **kwargs):
+    def __init__(self, *args, base_block=BaseConvBlock, n_repeats=1, **kwargs):
         base_block = kwargs.pop('base', None) or base_block
         self.n_repeats = n_repeats
         self.base_block = base_block
@@ -520,7 +521,7 @@ class ConvBlock:
                     block = item.pop('base_block', None) or item.pop('base', None) or base_block
                     block_args = {'inputs': inputs, **dict(Config(kwargs) + Config(item))}
                     inputs = block(**block_args)(inputs)
-                elif isinstance(item, K.Layer) or isinstance(item, Layer):
+                elif isinstance(item, (Layer, K.Layer)):
                     inputs = item(inputs)
                 else:
                     raise ValueError('Positional arguments of ConvBlock must be either dicts or nn.Modules, \
@@ -531,4 +532,3 @@ class ConvBlock:
             elif callable(base_block):
                 inputs = base_block(inputs=inputs, **kwargs)
         return inputs
-

--- a/batchflow/models/tf/layers/conv_block.py
+++ b/batchflow/models/tf/layers/conv_block.py
@@ -197,6 +197,7 @@ class BaseConvBlock:
         '+': 'residual_end',
         '.': 'residual_end',
         '*': 'residual_end',
+        '&': 'residual_end',
     }
 
     LAYERS_CLASSES = {

--- a/batchflow/models/tf/layers/core.py
+++ b/batchflow/models/tf/layers/core.py
@@ -1,4 +1,5 @@
 """ Contains common layers """
+from functools import partial
 import numpy as np
 import tensorflow as tf
 import tensorflow.keras.layers as K # pylint: disable=import-error
@@ -158,7 +159,6 @@ class Combine(Layer):
         """ Global Attention Upsample module. """
         from .conv_block import ConvBlock # can't be imported in the file beginning due to recursive imports
         from .resize import Crop
-        from functools import partial
         x, skip = inputs[0], inputs[1]
         num_dims = get_num_dims(skip) + 1
         leaky_relu = partial(tf.nn.leaky_relu, alpha=0.1)
@@ -209,7 +209,7 @@ class Combine(Layer):
                     force_resize = True
             if force_resize:
                 from .resize import Crop
-                inputs = [Crop(resize_to=inputs[-1])(item) for item in inputs]
+                inputs = [Crop(resize_to=inputs[-1], data_format=self.data_format)(item) for item in inputs]
 
             return op(inputs, data_format=self.data_format, **self.kwargs)
 

--- a/batchflow/models/tf/layers/core.py
+++ b/batchflow/models/tf/layers/core.py
@@ -7,8 +7,6 @@ from .layer import Layer, add_as_function
 
 
 
-
-
 @add_as_function
 class Flatten2D:
     """ Flatten tensor to two dimensions (batch_size, item_vector_size) """

--- a/batchflow/models/tf/layers/core.py
+++ b/batchflow/models/tf/layers/core.py
@@ -80,7 +80,7 @@ class Combine(Layer):
     data_format : str {'channels_last', 'channels_first'}
         Data format.
     leading_index : int
-        Index of tensor to broadcast to.
+        Index of tensor to broadcast to. Allows to change the order of input tensors.
     kwargs : dict
         Arguments for :class:`.ConvBlock`.
     """

--- a/batchflow/models/tf/layers/core.py
+++ b/batchflow/models/tf/layers/core.py
@@ -47,6 +47,7 @@ class Activation(Layer):
     def __call__(self, inputs):
         if self.activation is not None:
             return self.activation(inputs)
+        return inputs
 
 
 
@@ -88,6 +89,7 @@ class Combine(Layer):
     @staticmethod
     def concat(inputs, data_format='channels_last', axis=None, **kwargs):
         """ Concatenate tensors along specified axis or data format. """
+        _ = kwargs
         axis = axis or (1 if data_format == "channels_first" or data_format.startswith("NC") else -1)
         return tf.concat(inputs, axis=axis, name='combine-concat')
 

--- a/batchflow/models/tf/layers/core.py
+++ b/batchflow/models/tf/layers/core.py
@@ -38,7 +38,9 @@ class Flatten:
 
 @add_as_function
 class Activation(Layer):
-    """ Wrapper for activation functions. """
+    """ Wrapper for activation functions.
+    Used for `a` letter in layout convention of :class:`~.tf.layers.ConvBlock`.
+    """
     def __init__(self, activation, **kwargs):
         self.activation = activation
         self.kwargs = kwargs
@@ -52,7 +54,9 @@ class Activation(Layer):
 
 @add_as_function
 class Dense(Layer):
-    """ Wrapper for fully-connected layer. """
+    """ Wrapper for fully-connected layer.
+    Used for `f` letter in layout convention of :class:`~.tf.layers.ConvBlock`.
+    """
     def __init__(self, units, **kwargs):
         self.units = units
         self.kwargs = kwargs
@@ -67,6 +71,7 @@ class Dense(Layer):
 @add_as_function
 class Combine(Layer):
     """ Combine inputs into one tensor via various transformations.
+    Used for `.`, `+`, `*`, `&` letters in layout convention of :class:`~.tf.layers.ConvBlock`.
 
     Parameters
     ----------
@@ -77,6 +82,8 @@ class Combine(Layer):
         If one of 'sum', 'add', inputs are summed.
         If one of 'softsum', 'convsum', every tensor is passed through 1x1 convolution in order to have
         the same number of channels as the first tensor, and then summed.
+        If one of 'attention', 'gau', then the first tensor is used to create multiplicative attention for second,
+        and the output is added to second tensor.
 
     data_format : str {'channels_last', 'channels_first'}
         Data format.
@@ -150,7 +157,7 @@ class Combine(Layer):
         mul: ['multi', 'mul', '*'],
         mean: ['avg', 'mean', 'average'],
         softsum: ['softsum', '&'],
-        attention: ['attention'],
+        attention: ['attention', 'gau'],
     }
     OPS = {alias: getattr(method, '__func__') for method, aliases in OPS.items() for alias in aliases}
 
@@ -242,18 +249,23 @@ class BaseDropout(Layer):
 
 
 class Dropout(BaseDropout):
-    """ Wrapper for dropout layer. """
+    """ Wrapper for dropout layer.
+    Used for `d` letter in layout convention of :class:`~.tf.layers.ConvBlock`.
+    """
     LAYER = K.Dropout
 
 
 class AlphaDropout(BaseDropout):
-    """ Wrapper for self-normalizing dropout layer. """
+    """ Wrapper for self-normalizing dropout layer.
+    Used for `D` letter in layout convention of :class:`~.tf.layers.ConvBlock`.
+    """
     LAYER = K.AlphaDropout
 
 
 
 class BatchNormalization(Layer):
     """ Wrapper for batch normalization layer.
+    Used for `n` letter in layout convention of :class:`~.tf.layers.ConvBlock`.
 
     Note that Keras layers does not add update operations to `UPDATE_OPS` collection,
     so we must do it manually.
@@ -330,7 +342,9 @@ class Xip:
 
 @add_as_function
 class Mip(Layer):
-    """ Maximum intensity projection by shrinking the channels dimension with max pooling every ``depth`` channels """
+    """ Maximum intensity projection by shrinking the channels dimension with max pooling every ``depth`` channels.
+    Used for `m` letter in layout convention of :class:`~.tf.layers.ConvBlock`.
+    """
     def __init__(self, depth, data_format='channels_last', name='max'):
         self.depth, self.data_format = depth, data_format
         self.name = name

--- a/batchflow/models/tf/layers/drop_block.py
+++ b/batchflow/models/tf/layers/drop_block.py
@@ -15,7 +15,8 @@ from .pooling import MaxPooling
 
 @add_as_function
 class Dropblock(Layer):
-    """ Drop Block module.
+    """ Drop Block module
+    Used for `O` letter in layout convention of :class:`~.tf.layers.ConvBlock`.
 
     Parameters
     ----------

--- a/batchflow/models/tf/layers/pooling.py
+++ b/batchflow/models/tf/layers/pooling.py
@@ -158,7 +158,8 @@ class FractionalPooling:
 
 @add_as_function
 class Pooling(Layer):
-    """ Multi-dimensional pooling layer.
+    """ Multi-dimensional pooling layer
+    Used for `p`, 'v' letters in layout convention of :class:`~.tf.layers.ConvBlock`.
 
     Parameters
     ----------
@@ -203,6 +204,7 @@ class Pooling(Layer):
 @add_as_function
 class GlobalPooling(Layer):
     """ Multi-dimensional global pooling layer.
+    Used for `P`, `V` letters in layout convention of :class:`~.tf.layers.ConvBlock`.
 
     Parameters
     ----------

--- a/batchflow/models/tf/layers/pyramid.py
+++ b/batchflow/models/tf/layers/pyramid.py
@@ -64,7 +64,7 @@ def pyramid_pooling(inputs, layout='cna', filters=None, kernel_size=1, pool_op='
                     upsample_shape = dynamic_shape
 
                 # Conv block to set number of feature maps
-                x = ConvBlock(layout, filters=filters, kernel_size=kernel_size,
+                x = ConvBlock(layout=layout, filters=filters, kernel_size=kernel_size,
                               name='conv-%d' % level, **kwargs)(x)
 
                 # Output either vector with fixed size or tensor with fixed spatial dimensions
@@ -84,7 +84,7 @@ def _static_pyramid_pooling(inputs, spatial_shape, level, pool_op, **kwargs):
     pool_size = tuple(np.ceil(spatial_shape / level).astype(np.int32).tolist())
     pool_strides = tuple(np.floor((spatial_shape - 1) / level + 1).astype(np.int32).tolist())
 
-    output = ConvBlock('p', pool_op=pool_op, pool_size=pool_size, pool_strides=pool_strides, **kwargs)(inputs)
+    output = ConvBlock(layout='p', pool_op=pool_op, pool_size=pool_size, pool_strides=pool_strides, **kwargs)(inputs)
     return output
 
 def _dynamic_pyramid_pooling(inputs, level, pool_op, num_channels, data_format):
@@ -177,11 +177,11 @@ def aspp(inputs, layout='cna', filters=None, kernel_size=3, rates=(6, 12, 18), i
         image_level_features = (image_level_features,)
 
     with tf.variable_scope(name):
-        x = ConvBlock(layout, filters=filters, kernel_size=1, name='conv-1x1', **kwargs)(inputs)
+        x = ConvBlock(layout=layout, filters=filters, kernel_size=1, name='conv-1x1', **kwargs)(inputs)
         layers = [x]
 
         for level in rates:
-            x = ConvBlock(layout, filters=filters, kernel_size=kernel_size, dilation_rate=level,
+            x = ConvBlock(layout=layout, filters=filters, kernel_size=kernel_size, dilation_rate=level,
                           name='conv-%d' % level, **kwargs)(inputs)
             layers.append(x)
 
@@ -190,5 +190,5 @@ def aspp(inputs, layout='cna', filters=None, kernel_size=3, rates=(6, 12, 18), i
         layers.append(x)
 
         x = tf.concat(layers, axis=axis, name='concat')
-        x = ConvBlock(layout, filters=filters, kernel_size=1, name='last_conv', **kwargs)(x)
+        x = ConvBlock(layout=layout, filters=filters, kernel_size=1, name='last_conv', **kwargs)(x)
     return x

--- a/batchflow/models/tf/layers/resize.py
+++ b/batchflow/models/tf/layers/resize.py
@@ -5,6 +5,39 @@ import tensorflow as tf
 from .layer import Layer
 from .conv import ConvTranspose
 from .core import Xip
+from ..utils import get_shape, get_batch_size
+
+
+
+class IncreaseDim(Layer):
+    """ Increase dimensionality of passed tensor by desired amount. """
+    def __init__(self, dim=1, insert=True, name='increase_dim', **kwargs):
+        self.dim, self.insert = dim, insert
+        self.name, self.kwargs = name, kwargs
+
+    def __call__(self, inputs):
+        with tf.variable_scope(self.name):
+            batch_size = get_batch_size(inputs, dynamic=True)
+            shape = get_shape(inputs)
+            ones = [1] * self.dim
+            if self.insert:
+                return tf.reshape(inputs, (batch_size, *ones, *shape))
+            return tf.reshape(inputs, (batch_size, *shape, *ones))
+
+
+class Reshape(Layer):
+    """ Enforce desired shape of tensor. """
+    def __init__(self, reshape_to=None, name='reshape', **kwargs):
+        self.reshape_to = reshape_to
+        self.name, self.kwargs = name, kwargs
+
+    def __call__(self, inputs):
+        with tf.variable_scope(self.name):
+            print('I', inputs)
+            batch_size = get_batch_size(inputs, dynamic=True)
+            output = tf.reshape(inputs, (batch_size, *self.reshape_to))
+            print('O', output)
+            return output
 
 
 

--- a/batchflow/models/tf/layers/resize.py
+++ b/batchflow/models/tf/layers/resize.py
@@ -149,10 +149,10 @@ def _depth_to_space(inputs, block_size, name='d2s'):
 
 class UpsamplingLayer(Layer):
     """ Parent for all the upsampling layers with the same parameters. """
-    def __init__(self, factor=2, shape=None, data_format='channels_last', **kwargs):
+    def __init__(self, factor=2, shape=None, data_format='channels_last', name='upsampling', **kwargs):
         self.factor, self.shape = factor, shape
         self.data_format = data_format
-        self.kwargs = kwargs
+        self.name, self.kwargs = name, kwargs
 
 
 class SubpixelConv(UpsamplingLayer):

--- a/batchflow/models/tf/layers/resize.py
+++ b/batchflow/models/tf/layers/resize.py
@@ -150,7 +150,7 @@ def subpixel_conv(inputs, factor=2, name='subpixel', data_format='channels_last'
     with tf.variable_scope(name):
         if layout:
             from .conv_block import ConvBlock # can't be imported in the file beginning due to recursive imports
-            x = ConvBlock(layout, kernel_size=1, name='conv', data_format=data_format, **kwargs)(inputs)
+            x = ConvBlock(layout=layout, kernel_size=1, name='conv', data_format=data_format, **kwargs)(inputs)
         x = depth_to_space(x, block_size=factor, name='d2s', data_format=data_format)
     return x
 
@@ -180,7 +180,7 @@ def resize_bilinear_additive(inputs, factor=2, name='bilinear_additive', data_fo
     with tf.variable_scope(name):
         from .conv_block import ConvBlock # can't be imported in the file beginning due to recursive imports
         x = resize_bilinear(inputs, factor, name=name, data_format=data_format, **kwargs)
-        x = ConvBlock(layout, filters=channels*factor**dim, kernel_size=1, name='conv', **kwargs)(x)
+        x = ConvBlock(layout=layout, filters=channels*factor**dim, kernel_size=1, name='conv', **kwargs)(x)
         x = Xip(depth=factor**dim, reduction='sum', name='addition')(x)
     return x
 

--- a/batchflow/models/tf/mobilenet.py
+++ b/batchflow/models/tf/mobilenet.py
@@ -139,7 +139,8 @@ class MobileNet(TFModel):
         """
         num_filters = int(cls.num_channels(inputs, kwargs.get('data_format')) * width_factor)
         filters = [num_filters, num_filters*2] if double_filters else num_filters
-        return conv_block(inputs, 'Cna cna', filters, [3, 1], name=name, strides=[strides, 1], **kwargs)
+        return conv_block(inputs, layout='Cna cna', filters=filters, kernel_size=[3, 1], strides=[strides, 1],
+                          name=name, **kwargs)
 
 
 class MobileNet_v2(TFModel):
@@ -261,14 +262,14 @@ class MobileNet_v2(TFModel):
                 if k > 0:
                     strides = 1
                 num_filters = int(cls.num_channels(inputs, kwargs.get('data_format')) * expansion_factor * width_factor)
-                x = conv_block(inputs, 'cna wna', num_filters, [1, kernel_size], strides=[1, strides],
-                               name='-%d-exp' % k, **kwargs)
+                x = conv_block(inputs, layout='cna wna', filters=num_filters, kernel_size=[1, kernel_size],
+                               strides=[1, strides], name='-%d-exp' % k, **kwargs)
                 if se_block:
                     if not isinstance(se_block, dict):
                         se_block = dict(activation=[kwargs.get('activation', tf.nn.relu), h_sigmoid],
                                         ratio=num_filters // 4)
                     x = cls.se_block(x, name='-%d-se' % k, **{**kwargs, **se_block})
-                x = conv_block(x, 'cn', filters, 1, name='-%d-down' % k, **kwargs)
+                x = conv_block(x, layout='cn', filters=filters, kernel_size=1, name='-%d-down' % k, **kwargs)
                 if residual or k > 0:
                     x = combine((inputs, x), op=residual_agg)
                 inputs = x
@@ -295,9 +296,9 @@ class MobileNet_v2(TFModel):
         layout, filters, se_block = cls.pop(['layout', 'filters', 'se_block'], kwargs)
 
         if se_block:
-            x = conv_block(inputs, 'cna', filters[0], name='%s-conv1' % name, **kwargs)
+            x = conv_block(inputs, layout='cna', filters=filters[0], name='%s-conv1' % name, **kwargs)
             x = cls.se_block(x, **{**kwargs, **se_block}, name='%s-se' % name)
-            x = conv_block(x, 'vcacV', filters=filters[1:], name='%s-conv2' % name, **kwargs)
+            x = conv_block(x, layout='vcacV', filters=filters[1:], name='%s-conv2' % name, **kwargs)
             return x
         return conv_block(inputs, layout=layout, filters=filters, name=name, **kwargs)
 

--- a/batchflow/models/tf/refinenet.py
+++ b/batchflow/models/tf/refinenet.py
@@ -89,7 +89,7 @@ class RefineNet(TFModel):
         with tf.variable_scope(name):
             x, inputs = inputs, None
             x = cls.crop(x, targets, kwargs['data_format'])
-            x = conv_block(x, layout, filters=num_classes, kernel_size=kernel_size, **kwargs)
+            x = conv_block(x, layout=layout, filters=num_classes, kernel_size=kernel_size, **kwargs)
         return x
 
     @classmethod

--- a/batchflow/models/tf/resnet.py
+++ b/batchflow/models/tf/resnet.py
@@ -323,7 +323,7 @@ class ResNet(TFModel):
         """
         n = layout.count('c') + layout.count('C') - 1
         strides = ([2] + [1] * n) if downsample else 1
-        return conv_block(inputs, layout, filters=filters, kernel_size=kernel_size, strides=strides, **kwargs)
+        return conv_block(inputs, layout=layout, filters=filters, kernel_size=kernel_size, strides=strides, **kwargs)
 
     @classmethod
     def bottleneck_block(cls, inputs, layout=None, filters=None, kernel_size=None, bottleneck=None,
@@ -360,7 +360,7 @@ class ResNet(TFModel):
             strides = kwargs.pop('strides')
         if isinstance(filters, int):
             filters = [filters, filters, filters * bottleneck]
-        x = conv_block(inputs, layout, filters=filters, kernel_size=kernel_size, strides=strides, **kwargs)
+        x = conv_block(inputs, layout=layout, filters=filters, kernel_size=kernel_size, strides=strides, **kwargs)
         return x
 
     @classmethod

--- a/batchflow/models/tf/resnet.py
+++ b/batchflow/models/tf/resnet.py
@@ -416,7 +416,6 @@ class ResNet18(ResNet):
         config['body/block/bottleneck'] = None
         return config
 
-
 class ResNet34(ResNet):
     """ The original ResNet-34 architecture """
     @classmethod
@@ -426,7 +425,6 @@ class ResNet34(ResNet):
         config['body/block/bottleneck'] = None
         return config
 
-
 class ResNet50(ResNet):
     """ The original ResNet-50 architecture """
     @classmethod
@@ -434,7 +432,6 @@ class ResNet50(ResNet):
         config = ResNet34.default_config()
         config['body/block/bottleneck'] = 4
         return config
-
 
 class ResNet101(ResNet):
     """ The original ResNet-101 architecture """
@@ -444,7 +441,6 @@ class ResNet101(ResNet):
         config['body/num_blocks'] = [3, 4, 23, 3]
         config['body/block/bottleneck'] = 4
         return config
-
 
 class ResNet152(ResNet):
     """ The original ResNet-152 architecture """
@@ -464,7 +460,6 @@ class ResNeXt18(ResNet):
         config['body/block/resnext'] = 32
         return config
 
-
 class ResNeXt34(ResNet):
     """ The ResNeXt-34 architecture """
     @classmethod
@@ -472,7 +467,6 @@ class ResNeXt34(ResNet):
         config = ResNet34.default_config()
         config['body/block/resnext'] = 32
         return config
-
 
 class ResNeXt50(ResNet):
     """ The ResNeXt-50 architecture """
@@ -482,7 +476,6 @@ class ResNeXt50(ResNet):
         config['body/block/resnext'] = 32
         return config
 
-
 class ResNeXt101(ResNet):
     """ The ResNeXt-101 architecture """
     @classmethod
@@ -491,11 +484,92 @@ class ResNeXt101(ResNet):
         config['body/block/resnext'] = 32
         return config
 
-
 class ResNeXt152(ResNet):
     """ The ResNeXt-152 architecture """
     @classmethod
     def default_config(cls):
         config = ResNet152.default_config()
         config['body/block/resnext'] = 32
+        return config
+
+
+class SEResNet18(ResNet):
+    """ The ResNet-18 architecture with squeeze-and-excitation blocks."""
+    @classmethod
+    def default_config(cls):
+        config = ResNet18.default_config()
+        config['body/block/se_block/ratio'] = 16
+        return config
+
+class SEResNet34(ResNet):
+    """ The ResNet-34 architecture with squeeze-and-excitation blocks."""
+    @classmethod
+    def default_config(cls):
+        config = ResNet34.default_config()
+        config['body/block/se_block/ratio'] = 16
+        return config
+
+class SEResNet50(ResNet):
+    """ The ResNet-50 architecture with squeeze-and-excitation blocks."""
+    @classmethod
+    def default_config(cls):
+        config = ResNet50.default_config()
+        config['body/block/se_block/ratio'] = 16
+        return config
+
+class SEResNet101(ResNet):
+    """ The ResNet-101 architecture with squeeze-and-excitation blocks."""
+    @classmethod
+    def default_config(cls):
+        config = ResNet101.default_config()
+        config['body/block/se_block/ratio'] = 16
+        return config
+
+class SEResNet152(ResNet):
+    """ The ResNet-152 architecture with squeeze-and-excitation blocks."""
+    @classmethod
+    def default_config(cls):
+        config = ResNet152.default_config()
+        config['body/block/se_block/ratio'] = 16
+        return config
+
+
+class SEResNeXt18(ResNet):
+    """ The ResNeXt-18 architecture with squeeze-and-excitation blocks."""
+    @classmethod
+    def default_config(cls):
+        config = ResNeXt18.default_config()
+        config['body/block/se_block/ratio'] = 16
+        return config
+
+class SEResNeXt34(ResNet):
+    """ The ResNeXt-34 architecture with squeeze-and-excitation blocks."""
+    @classmethod
+    def default_config(cls):
+        config = ResNeXt34.default_config()
+        config['body/block/se_block/ratio'] = 16
+        return config
+
+class SEResNeXt50(ResNet):
+    """ The ResNeXt-50 architecture with squeeze-and-excitation blocks."""
+    @classmethod
+    def default_config(cls):
+        config = ResNeXt50.default_config()
+        config['body/block/se_block/ratio'] = 16
+        return config
+
+class SEResNeXt101(ResNet):
+    """ The ResNeXt-101 architecture with squeeze-and-excitation blocks."""
+    @classmethod
+    def default_config(cls):
+        config = ResNeXt101.default_config()
+        config['body/block/se_block/ratio'] = 16
+        return config
+
+class SEResNeXt152(ResNet):
+    """ The ResNeXt-152 architecture with squeeze-and-excitation blocks."""
+    @classmethod
+    def default_config(cls):
+        config = ResNeXt152.default_config()
+        config['body/block/se_block/ratio'] = 16
         return config

--- a/batchflow/models/tf/squeezenet.py
+++ b/batchflow/models/tf/squeezenet.py
@@ -90,14 +90,15 @@ class SqueezeNet(TFModel):
                     x = cls.fire_block(x, filters=filters[block_no], name='fire-block-%d' % i, **{**kwargs, **block})
                     block_no += 1
                 elif b == 'm':
-                    x = conv_block(x, 'p', name='max-pool-%d' % i, **kwargs)
+                    x = conv_block(x, layout='p', name='max-pool-%d' % i, **kwargs)
 
                 if bypass is not None:
                     bypass_channels = cls.num_channels(bypass, kwargs.get('data_format'))
                     x_channels = cls.num_channels(x, kwargs.get('data_format'))
 
                     if x_channels != bypass_channels:
-                        bypass = conv_block(bypass, 'c', x_channels, 1, name='bypass-%d' % i, **kwargs)
+                        bypass = conv_block(bypass, layout='c', filters=x_channels, kernel_size=1,
+                                            name='bypass-%d' % i, **kwargs)
                     x = x + bypass
                     bypass = None
         return x
@@ -119,10 +120,10 @@ class SqueezeNet(TFModel):
         """
         with tf.variable_scope(name):
             x, inputs = inputs, None
-            x = conv_block(x, layout, filters, 1, name='squeeze-1x1', **kwargs)
+            x = conv_block(x, layout=layout, filters=filters, kernel_size=1, name='squeeze-1x1', **kwargs)
 
-            exp1 = conv_block(x, layout, filters*4, 1, name='expand-1x1', **kwargs)
-            exp3 = conv_block(x, layout, filters*4, 3, name='expand-3x3', **kwargs)
+            exp1 = conv_block(x, layout=layout, filters=filters*4, kernel_size=1, name='expand-1x1', **kwargs)
+            exp3 = conv_block(x, layout=layout, filters=filters*4, kernel_size=3, name='expand-3x3', **kwargs)
 
             axis = cls.channels_axis(kwargs.get('data_format'))
             x = tf.concat([exp1, exp3], axis=axis)

--- a/batchflow/models/tf/utils.py
+++ b/batchflow/models/tf/utils.py
@@ -1,0 +1,93 @@
+""" Utility functions. """
+import tensorflow as tf
+
+
+
+def get_shape(tensor, dynamic=False):
+    """ Return shape of the input tensor without batch size.
+
+    Parameters
+    ----------
+    tensor : tf.Tensor
+
+    dynamic : bool
+        If True, returns tensor which represents shape. If False, returns list of ints and/or Nones.
+
+    Returns
+    -------
+    shape : tf.Tensor or list
+    """
+    if dynamic:
+        shape = tf.shape(tensor)
+    else:
+        shape = tensor.get_shape().as_list()
+    return shape[1:]
+
+
+def get_channels_axis(data_format='channels_last'):
+    """ Return the integer channels axis based on string data format. """
+    return 1 if data_format == "channels_first" or data_format.startswith("NC") else -1
+
+def get_num_channels(tensor, data_format='channels_last'):
+    """ Return number of channels in the input tensor.
+
+    Parameters
+    ----------
+    tensor : tf.Tensor
+
+    Returns
+    -------
+    shape : tuple of ints
+    """
+    shape = tensor.get_shape().as_list()
+    axis = get_channels_axis(data_format)
+    return shape[axis]
+
+
+def get_batch_size(tensor):
+    """ Return batch size (the length of the first dimension) of the input tensor.
+
+    Parameters
+    ----------
+    tensor : tf.Tensor
+
+    Returns
+    -------
+    batch size : int or None
+    """
+    return tensor.get_shape().as_list()[0]
+
+
+def get_spatial_dim(tensor):
+    """ Return spatial dim of the input tensor (without channels and batch dimension).
+
+    Parameters
+    ----------
+    tensor : tf.Tensor
+
+    Returns
+    -------
+    dim : int
+    """
+    return len(tensor.get_shape().as_list()) - 2
+
+def get_spatial_shape(tensor, data_format='channels_last', dynamic=False):
+    """ Return the tensor spatial shape (without batch and channels dimensions).
+
+    Parameters
+    ----------
+    tensor : tf.Tensor
+
+    dynamic : bool
+        If True, returns tensor which represents shape. If False, returns list of ints and/or Nones.
+
+    Returns
+    -------
+    shape : tf.Tensor or list
+    """
+    if dynamic:
+        shape = tf.shape(tensor)
+    else:
+        shape = tensor.get_shape().as_list()
+    axis = slice(1, -1) if data_format == "channels_last" else slice(2, None)
+    return shape[axis]

--- a/batchflow/models/tf/utils.py
+++ b/batchflow/models/tf/utils.py
@@ -23,6 +23,12 @@ def get_shape(tensor, dynamic=False):
         shape = tensor.get_shape().as_list()
     return shape[1:]
 
+def get_num_dims(tensor):
+    """ Return a number of semantic dimensions (i.e. excluding batch and channels axis)"""
+    shape = get_shape(tensor)
+    dim = len(shape)
+    return max(1, dim - 2)
+
 
 def get_channels_axis(data_format='channels_last'):
     """ Return the integer channels axis based on string data format. """
@@ -44,7 +50,7 @@ def get_num_channels(tensor, data_format='channels_last'):
     return shape[axis]
 
 
-def get_batch_size(tensor):
+def get_batch_size(tensor, dynamic=False):
     """ Return batch size (the length of the first dimension) of the input tensor.
 
     Parameters
@@ -55,6 +61,8 @@ def get_batch_size(tensor):
     -------
     batch size : int or None
     """
+    if dynamic:
+        return tf.shape(tensor)[0]
     return tensor.get_shape().as_list()[0]
 
 

--- a/batchflow/models/tf/vgg.py
+++ b/batchflow/models/tf/vgg.py
@@ -123,7 +123,8 @@ class VGG(TFModel):
         layout = kwargs.pop('layout') * (depth3 + depth1) + 'p' * downscale
         kernels = [3] * depth3 + [1] * depth1
         with tf.variable_scope(name):
-            x = conv_block(inputs, layout, filters, kernels, name='conv', **kwargs)
+            x = conv_block(inputs, layout=layout, filters=filters, kernel_size=kernels,
+                           name='conv', **kwargs)
             x = tf.identity(x, name='output')
         return x
 

--- a/batchflow/models/tf/xception.py
+++ b/batchflow/models/tf/xception.py
@@ -103,7 +103,7 @@ class Xception(TFModel):
         with tf.variable_scope(name):
             x = depthwise_conv(inputs, kernel_size=kernel_size, strides=strides, dilation_rate=rate,
                                data_format=data_format, padding='same', name='depthwise')
-            x = conv_block(x, layout, filters=filters, kernel_size=1, **kwargs)
+            x = conv_block(x, layout=layout, filters=filters, kernel_size=1, **kwargs)
         return x
 
 

--- a/batchflow/tests/notebooks/tfmodel_test.ipynb
+++ b/batchflow/tests/notebooks/tfmodel_test.ipynb
@@ -171,15 +171,17 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2019-08-19T09:50:09.698242Z",
-     "start_time": "2019-08-19T09:50:08.873326Z"
+     "end_time": "2020-02-04T09:12:20.455897Z",
+     "start_time": "2020-02-04T09:12:19.224361Z"
     }
    },
    "outputs": [],
    "source": [
     "config = {\n",
-    "    'initial_block': {'layout': 'fa'*2,\n",
-    "                      'units': [64, 128],},\n",
+    "    'initial_block': {'layout': 'S>>r' + 'fa'*2,\n",
+    "                      'units': [64, 128],\n",
+    "                      'attention_mode': 'scse',\n",
+    "                      'reshape_to': (28, 14, 2)},\n",
     "    'body': {'layout': 'fa'*2,\n",
     "             'units': [256, 512]},\n",
     "    'head': {'layout': 'faf',\n",
@@ -247,8 +249,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2019-08-19T09:51:01.668654Z",
-     "start_time": "2019-08-19T09:50:20.973399Z"
+     "end_time": "2020-02-04T09:12:51.059150Z",
+     "start_time": "2020-02-04T09:12:20.791711Z"
     }
    },
    "outputs": [],
@@ -256,6 +258,7 @@
     "config = {\n",
     "    'initial_block/filters': 4,\n",
     "    'body/encoder': {'num_stages': 3},\n",
+    "    'body/decoder/blocks/combine_op': 'attention',\n",
     "}\n",
     "\n",
     "ppl = run('segmentation', UNet, config, 'unet')"

--- a/batchflow/tests/notebooks/tfmodel_test.ipynb
+++ b/batchflow/tests/notebooks/tfmodel_test.ipynb
@@ -194,8 +194,26 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2019-08-19T09:50:20.970997Z",
-     "start_time": "2019-08-19T09:50:09.705192Z"
+     "end_time": "2020-02-03T07:06:25.625232Z",
+     "start_time": "2020-02-03T07:06:12.652191Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "config = {\n",
+    "    'head/layout': 'f'\n",
+    "}\n",
+    "\n",
+    "ppl = run('classification', ResNet18, config, 'ResNet18')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-02-03T07:06:11.018342Z",
+     "start_time": "2020-02-03T07:05:52.039725Z"
     }
    },
    "outputs": [],

--- a/batchflow/tests/notebooks/tfmodel_test.ipynb
+++ b/batchflow/tests/notebooks/tfmodel_test.ipynb
@@ -194,13 +194,14 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-02-03T07:06:25.625232Z",
-     "start_time": "2020-02-03T07:06:12.652191Z"
+     "end_time": "2020-02-03T07:40:59.308835Z",
+     "start_time": "2020-02-03T07:40:44.695229Z"
     }
    },
    "outputs": [],
    "source": [
     "config = {\n",
+    "    'body/block/se_block': {'ratio':8},\n",
     "    'head/layout': 'f'\n",
     "}\n",
     "\n",
@@ -265,8 +266,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2019-08-19T09:51:10.594428Z",
-     "start_time": "2019-08-19T09:51:01.670903Z"
+     "end_time": "2020-02-03T07:37:10.920096Z",
+     "start_time": "2020-02-03T07:36:57.661643Z"
     }
    },
    "outputs": [],
@@ -274,7 +275,8 @@
     "config = {\n",
     "    'initial_block': {'layout': 'cna', 'filters': 2},\n",
     "    'body/encoder': {'base': ResNet18,\n",
-    "                     'filters':[4]*4},\n",
+    "                     'filters':[4]*4,\n",
+    "                     'downsample': [[]] + [[0]]*4},\n",
     "    'body/embedding': [{'layout': 'cna', 'filters': 16}]*4,\n",
     "}\n",
     "\n",
@@ -286,8 +288,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2019-08-19T09:51:48.231548Z",
-     "start_time": "2019-08-19T09:51:10.596436Z"
+     "end_time": "2020-02-03T07:38:10.811772Z",
+     "start_time": "2020-02-03T07:37:10.921740Z"
     }
    },
    "outputs": [],
@@ -296,7 +298,8 @@
     "    'initial_block': {'layout': 'cna', 'filters': 4},\n",
     "    'body/encoder': {'base': ResNet,\n",
     "                     'num_blocks': [2, 2, 2, 2, 2],\n",
-    "                     'filters': [2, 4, 8, 16, 32]},\n",
+    "                     'filters': [2, 4, 8, 16, 32],\n",
+    "                     'downsample': [[]] + [[0]]*4},\n",
     "    'body/embedding': {'filters': 32},\n",
     "    'body/decoder': {'num_stages': 5,\n",
     "                     'factor': 32,\n",

--- a/batchflow/tests/notebooks/tfmodel_test.ipynb
+++ b/batchflow/tests/notebooks/tfmodel_test.ipynb
@@ -325,13 +325,42 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2019-08-19T09:52:03.585010Z",
-     "start_time": "2019-08-19T09:51:48.233321Z"
+     "end_time": "2020-02-05T12:42:13.259519Z",
+     "start_time": "2020-02-05T12:41:47.454064Z"
     }
    },
    "outputs": [],
    "source": [
     "ppl = run('segmentation', DeepLabXS, {}, 'DeepLab XS')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-02-05T13:21:49.768970Z",
+     "start_time": "2020-02-05T13:21:39.807243Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "config = {\n",
+    "    'initial_block': {'layout': 'cna', 'filters': 4},\n",
+    "    'body/encoder/num_stages': 3,\n",
+    "    'body/encoder/blocks': {'base': ResNet.block,\n",
+    "                            'filters': [8, 8, 8],},\n",
+    "    'body/embedding/filters': 32,\n",
+    "    'body/decoder': {\n",
+    "                     'skip': True,\n",
+    "                     'upsample': {'layout': 'X'},\n",
+    "                     'blocks': {'base': DenseNet.block,\n",
+    "                                'num_layers': [2, 2, 2],\n",
+    "                                'growth_rate': 2,\n",
+    "                                'skip': False}},\n",
+    "}\n",
+    "\n",
+    "ppl = run('segmentation', EncoderDecoder, config, 'encoder-decoder with ResNet blocks, DenseNet blocks')"
    ]
   }
  ],

--- a/batchflow/tests/tf_models_compile_test.py
+++ b/batchflow/tests/tf_models_compile_test.py
@@ -10,6 +10,8 @@ from batchflow.models.tf import LinkNet, UNet, VNet, \
                                 VGG16, VGG19, VGG7, \
                                 ResNet18, ResNet34, ResNet50, ResNet101, ResNet152, \
                                 ResNeXt18, ResNeXt34, ResNeXt50, ResNeXt101, ResNeXt152, \
+                                SEResNet18, SEResNet34, SEResNet50, SEResNet101, SEResNet152, \
+                                SEResNeXt18, SEResNeXt34, SEResNeXt50, SEResNeXt101, SEResNeXt152, \
                                 Inception_v1, InceptionResNet_v2, Inception_v3, Inception_v4, \
                                 SqueezeNet, MobileNet, MobileNet_v2, MobileNet_v3, MobileNet_v3_small, \
                                 DenseNet121, DenseNet169, DenseNet201, DenseNet264, \
@@ -26,14 +28,16 @@ MODELS_CLF = [
     VGG7, VGG16, VGG19,
     ResNet18, ResNet34, # ResNet50, ResNet101, ResNet152,
     ResNeXt18, ResNeXt34, # ResNeXt50, ResNeXt101, ResNeXt152,
+    SEResNet18, SEResNet34, # SEResNet50, SEResNet101, SEResNet152,
+    SEResNeXt18, SEResNeXt34, # SEResNeXt50, SEResNeXt101, SEResNeXt152,
     Inception_v1,
-    # InceptionResNet_v2, Inception_v3, Inception_v4, # fail
+    # InceptionResNet_v2, Inception_v3, Inception_v4, # need bigger spatial size of inputs (256)
     SqueezeNet,
     MobileNet, MobileNet_v2, MobileNet_v3, MobileNet_v3_small,
-    DenseNet121,  # DenseNet169, DenseNet201, DenseNet264,
+    DenseNet121, # DenseNet169, DenseNet201, DenseNet264,
     ResNetAttention56, # ResNetAttention92,
     PyramidNet18, PyramidNet34, # PyramidNet50, PyramidNet101,
-    XceptionS, Xception41, # Xception64
+    XceptionS, Xception41, # Xception64,
     EfficientNetB0, EfficientNetB1, # EfficientNetB2, EfficientNetB3, \
     # EfficientNetB4, EfficientNetB5, EfficientNetB6, EfficientNetB7
 ]

--- a/batchflow/tests/tf_models_compile_test.py
+++ b/batchflow/tests/tf_models_compile_test.py
@@ -35,8 +35,8 @@ MODELS_CLF = [
     SqueezeNet,
     MobileNet, MobileNet_v2, MobileNet_v3, MobileNet_v3_small,
     DenseNet121, # DenseNet169, DenseNet201, DenseNet264,
-    ResNetAttention56, # ResNetAttention92,
-    PyramidNet18, PyramidNet34, # PyramidNet50, PyramidNet101,
+    # ResNetAttention56, # ResNetAttention92,
+    # PyramidNet18, PyramidNet34, # PyramidNet50, PyramidNet101,
     XceptionS, Xception41, # Xception64,
     EfficientNetB0, EfficientNetB1, # EfficientNetB2, EfficientNetB3, \
     # EfficientNetB4, EfficientNetB5, EfficientNetB6, EfficientNetB7

--- a/batchflow/tests/tf_models_compile_test.py
+++ b/batchflow/tests/tf_models_compile_test.py
@@ -35,8 +35,8 @@ MODELS_CLF = [
     SqueezeNet,
     MobileNet, MobileNet_v2, MobileNet_v3, MobileNet_v3_small,
     DenseNet121, # DenseNet169, DenseNet201, DenseNet264,
-    # ResNetAttention56, # ResNetAttention92,
-    # PyramidNet18, PyramidNet34, # PyramidNet50, PyramidNet101,
+    # ResNetAttention56, # ResNetAttention92, # not working
+    # PyramidNet18, PyramidNet34, # PyramidNet50, PyramidNet101, # not working
     XceptionS, Xception41, # Xception64,
     EfficientNetB0, EfficientNetB1, # EfficientNetB2, EfficientNetB3, \
     # EfficientNetB4, EfficientNetB5, EfficientNetB6, EfficientNetB7


### PR DESCRIPTION
This PR proposes to:

- Make `ConvBlock` able to chain multiple layers, just like `Torch` version can

- Simplify logic of letter parsing, as well as adding capability of using `R` letter as separate `Branch` with complex parameters

- Swap all arguments inside calls to `conv_block` to keyword ones

- Add `squeeze-and-excitation` versions of `ResNet`

- Re-check all the tests of model compilation

- Add various attention modules: some of them are available through `S` (stands for self-attention) letter, some of them are mods of `Combine`