### PR TITLE
exec init_model in pipeline before

### DIFF
--- a/batchflow/_const.py
+++ b/batchflow/_const.py
@@ -4,6 +4,7 @@ JOIN_ID = '#_join'
 MERGE_ID = '#_merge'
 REBATCH_ID = '#_rebatch'
 PIPELINE_ID = '#_pipeline'
+INIT_MODEL_ID = '#_init_model'
 IMPORT_MODEL_ID = '#_import_model'
 TRAIN_MODEL_ID = '#_train_model'
 PREDICT_MODEL_ID = '#_predict_model'
@@ -17,6 +18,7 @@ PRINT_ID = '#_print'
 CALL_FROM_NS_ID = '#_from_ns'
 
 ACTIONS = {
+    INIT_MODEL_ID: '_exec_init_model',
     IMPORT_MODEL_ID: '_exec_import_model',
     TRAIN_MODEL_ID: '_exec_train_model',
     PREDICT_MODEL_ID: '_exec_predict_model',

--- a/batchflow/once_pipeline.py
+++ b/batchflow/once_pipeline.py
@@ -142,15 +142,14 @@ class OncePipeline:
         >>> pipeline.before
               .init_model('dynamic', MyModel, config={'input_shape': C(lambda batch: batch.images.shape[1:])})
         """
-        self._add_action(INIT_MODEL_ID, _args=dict(mode=mode, model_class=model_class, model_name=name, config=config))
-        return self
+        action = dict(mode=mode, model_class=model_class, model_name=name, config=config)
+        if mode == 'static':
+            self._exec_init_model(action)
+            return self
+        return self._add_action(INIT_MODEL_ID, _args=action)
 
     def _exec_init_model(self, action):
-        name = eval_expr(action['model_name'], pipeline=self.pipeline)
-        model_class = eval_expr(action['model_class'], pipeline=self.pipeline)
-        mode = eval_expr(action['mode'], pipeline=self.pipeline)
-        config = eval_expr(action['config'], pipeline=self.pipeline)
-        self.pipeline.models.init_model(mode, model_class, name, config)
+        self.pipeline._exec_init_model(None, action)
 
     def save_model(self, name, *args, **kwargs):
         """ Save a model """

--- a/batchflow/once_pipeline.py
+++ b/batchflow/once_pipeline.py
@@ -6,7 +6,7 @@ import logging
 import numpy as np
 
 from .named_expr import NamedExpression, eval_expr
-from ._const import ACTIONS, LOAD_MODEL_ID, SAVE_MODEL_ID, UPDATE_ID
+from ._const import ACTIONS, LOAD_MODEL_ID, SAVE_MODEL_ID, UPDATE_ID, INIT_MODEL_ID
 
 
 class OncePipeline:
@@ -142,8 +142,15 @@ class OncePipeline:
         >>> pipeline.before
               .init_model('dynamic', MyModel, config={'input_shape': C(lambda batch: batch.images.shape[1:])})
         """
-        self.pipeline.models.init_model(mode, model_class, name, config=config)
+        self._add_action(INIT_MODEL_ID, _args=dict(mode=mode, model_class=model_class, model_name=name, config=config))
         return self
+
+    def _exec_init_model(self, action):
+        name = eval_expr(action['model_name'], pipeline=self.pipeline)
+        model_class = eval_expr(action['model_class'], pipeline=self.pipeline)
+        mode = eval_expr(action['mode'], pipeline=self.pipeline)
+        config = eval_expr(action['config'], pipeline=self.pipeline)
+        self.pipeline.models.init_model(mode, model_class, name, config)
 
     def save_model(self, name, *args, **kwargs):
         """ Save a model """

--- a/batchflow/pipeline.py
+++ b/batchflow/pipeline.py
@@ -794,6 +794,13 @@ class Pipeline:
         """
         self.before.init_model(mode, model_class, name, config)
         return self
+    
+    def _exec_init_model(self, batch, action):
+        mode = self._eval_expr(action['mode'], batch=batch)
+        name = self._eval_expr(action['model_name'], batch=batch)
+        model_class = self._eval_expr(action['model_class'], batch=batch)
+        config = self._eval_expr(action['config'], batch=batch)
+        self.models.init_model(mode, model_class, name, config)
 
     def import_model(self, model, pipeline=None, name=None):
         """ Import a model from another pipeline

--- a/batchflow/tests/pipeline_init_model_test.py
+++ b/batchflow/tests/pipeline_init_model_test.py
@@ -1,0 +1,47 @@
+import pytest 
+
+from batchflow import DatasetIndex, Pipeline, Batch, C
+from batchflow.models import BaseModel
+from batchflow.model_dir import NonInitializedModel
+
+@pytest.fixture
+def dataset():
+    index = DatasetIndex(100)
+    return Dataset(index, Batch)
+
+@pytest.mark.parametrize('use_algebra', [True, False])
+@pytest.mark.parametrize('config', [dict(mode='static', base_class=BaseModel, name='model', config={}),
+                                    dict(mode='dynamic', base_class=BaseModel, name='model', config={})])
+def test_single_model(use_algebra, config, dataset):
+    if not use_algebra:
+        pipeline = dataset.pipeline(config).init_model(C('mode'), C('base_class'), C('name'), C('config'))
+    else:
+        pipeline = dataset.pipeline().init_model(C('mode'), C('class'), C('base_name'), C('config')) << config
+    pipeline.next_batch(1)
+
+    if config['mode'] == 'static': 
+        assert type(pipeline.m(config['name']) == config['class']
+    else:
+        assert type(pipeline.m(config['name']) == NonInitializedModel
+
+# @pytest.mark.parametrize('use_algebra1', [True, False])
+# @pytest.mark.parametrize('use_algebra2', [True, False])
+# @pytest.mark.parametrize('mode', ['static', 'dynamic'])
+# @pytest.mark.parametrize('config1', 'config2' [(dict(class=BaseModel, name='model1', config={}),
+#                                                 dict(class=BaseModel, name='model2', config={})])
+# def test_multiple_models(dataset, use_algebra1, use_algebra2, mode,  config1, config2):
+#     config1.update(mode=mode)
+#     if not use_algebra1:
+#         pipeline = dataset.pipeline(config1).init_model(C('mode'), C('class'), C('name'), C('config'))
+#     else:
+#         pipeline = dataset.p.init_model(C('mode'), C('class'), C('name'), C('config')) << config1
+#     pipeline.next_batch(1)
+
+#     config2.update(mode=mode)
+#     if not use_algebra2:
+#         pipeline = pipeline.update_config(config2)
+#     else:
+#         pipeline = pipeline << config2
+#     pipeline.next_batch(1)
+
+#     assert type(pipeline.m(config1['name']) == type(pipeline.m(config2['name'])

--- a/batchflow/tests/pipeline_init_model_test.py
+++ b/batchflow/tests/pipeline_init_model_test.py
@@ -1,3 +1,5 @@
+""" Tests for pipeline init_model action """
+# pylint: disable=import-error, no-name-in-module
 import pytest 
 
 from batchflow import DatasetIndex, Pipeline, Batch, C
@@ -6,6 +8,7 @@ from batchflow.model_dir import NonInitializedModel
 
 @pytest.fixture
 def dataset():
+    """ Toy dataset """
     index = DatasetIndex(100)
     return Dataset(index, Batch)
 
@@ -13,6 +16,9 @@ def dataset():
 @pytest.mark.parametrize('config', [dict(mode='static', base_class=BaseModel, name='model', config={}),
                                     dict(mode='dynamic', base_class=BaseModel, name='model', config={})])
 def test_single_model(use_algebra, config, dataset):
+    """ Verifies that the model in init_model is initialized as expected with config provided, i.e.
+    pipeline contains the model with given name belongs to given class.
+    Also veriying methods of linking config to the pipeline: via pipeline algebra and manually. """
     if not use_algebra:
         pipeline = dataset.pipeline(config).init_model(C('mode'), C('base_class'), C('name'), C('config'))
     else:
@@ -24,24 +30,26 @@ def test_single_model(use_algebra, config, dataset):
     else:
         assert type(pipeline.m(config['name']) == NonInitializedModel
 
-# @pytest.mark.parametrize('use_algebra1', [True, False])
-# @pytest.mark.parametrize('use_algebra2', [True, False])
-# @pytest.mark.parametrize('mode', ['static', 'dynamic'])
-# @pytest.mark.parametrize('config1', 'config2' [(dict(class=BaseModel, name='model1', config={}),
-#                                                 dict(class=BaseModel, name='model2', config={})])
-# def test_multiple_models(dataset, use_algebra1, use_algebra2, mode,  config1, config2):
-#     config1.update(mode=mode)
-#     if not use_algebra1:
-#         pipeline = dataset.pipeline(config1).init_model(C('mode'), C('class'), C('name'), C('config'))
-#     else:
-#         pipeline = dataset.p.init_model(C('mode'), C('class'), C('name'), C('config')) << config1
-#     pipeline.next_batch(1)
+@pytest.mark.parametrize('use_algebra1', [True, False])
+@pytest.mark.parametrize('use_algebra2', [True, False])
+@pytest.mark.parametrize('mode', ['static', 'dynamic'])
+@pytest.mark.parametrize('config1', 'config2' [(dict(class=BaseModel, name='model1', config={}),
+                                                dict(class=BaseModel, name='model2', config={})])
+def test_multiple_models(dataset, use_algebra1, use_algebra2, mode,  config1, config2):
+    """ Verifies that several modeles can be initialized and stored in the pipeline via sequentially linking
+    different configs to the pipeline. """
+    config1.update(mode=mode)
+    if not use_algebra1:
+        pipeline = dataset.pipeline(config1).init_model(C('mode'), C('class'), C('name'), C('config'))
+    else:
+        pipeline = dataset.p.init_model(C('mode'), C('class'), C('name'), C('config')) << config1
+    pipeline.next_batch(1)
 
-#     config2.update(mode=mode)
-#     if not use_algebra2:
-#         pipeline = pipeline.update_config(config2)
-#     else:
-#         pipeline = pipeline << config2
-#     pipeline.next_batch(1)
+    config2.update(mode=mode)
+    if not use_algebra2:
+        pipeline = pipeline.update_config(config2)
+    else:
+        pipeline = pipeline << config2
+    pipeline.next_batch(1)
 
-#     assert type(pipeline.m(config1['name']) == type(pipeline.m(config2['name'])
+    assert type(pipeline.m(config1['name']) == type(pipeline.m(config2['name'])


### PR DESCRIPTION
`init_model` are not unpacking arguments passed as `NamedExpressions`.
e.g. pipeline
```
pipeline_config = dict(model_class=Resnet18, model_name='my_model')
pipeline = (data.pipeline(pipeline_config)
                    .init_model('dynamic', C('model_class'), C('name'), model_config) 
                    .train_model(C('name'), ...)

```
Throws the error since `train_model` tries to get `my_model` model which exists under the other name in the pipeline (NamedExpression itself).