### PR TITLE
remove randomization in show_research

### DIFF
--- a/batchflow/batch.py
+++ b/batchflow/batch.py
@@ -266,13 +266,12 @@ class Batch(metaclass=MethodsTransformingMeta):
                 new_comp = [b.get(component=comp) for b in batches]
             else:
                 last_batch = batches[break_point]
-                last_batch_last_index = last_batch.get_pos(None, comp, last_batch.indices[last_batch_len - 1])
                 new_comp = [b.get(component=comp) for b in batches[:break_point]] + \
-                           [last_batch.get(component=comp)[:last_batch_last_index + 1]]
+                           [last_batch.get(component=comp)[:last_batch_len]]
             new_data[i] = cls.merge_component(comp, new_comp)
 
             if batch_size is not None:
-                rest_comp = [last_batch.get(component=comp)[last_batch_last_index + 1:]] + \
+                rest_comp = [last_batch.get(component=comp)[last_batch_len:]] + \
                             [b.get(component=comp) for b in batches[break_point + 1:]]
                 rest_data[i] = cls.merge_component(comp, rest_comp)
 

--- a/batchflow/utils.py
+++ b/batchflow/utils.py
@@ -3,6 +3,8 @@ import sys
 import copy
 import math
 import functools
+import itertools
+
 import tqdm
 
 import numpy as np
@@ -150,8 +152,13 @@ def show_research(df, layouts=None, titles=None, average_repetitions=False, log_
         If True, values will be logarithmised.
     rolling_window : int of sequence of ints, optional
         Size of rolling window.
-    color: sequence of matplotlib.colors, optional
-        Colors for plots would be randomly sampled from given set.
+    color: str or sequence of matplotlib.colors, optional
+        If str, should be a name of matplotlib colormap, 
+        colors for plots will be selected from that colormap.
+        If sequence of colors, they will be used for plots, 
+        if sequence length is less, than number of lines to plot, 
+        colors will be repeated in cycle
+        If None (default), `mcolors.TABLEAU_COLORS` sequence is used
     kwargs:
         Additional named arguments directly passed to `plt.subplots`.
         With default parameters:
@@ -175,8 +182,12 @@ def show_research(df, layouts=None, titles=None, average_repetitions=False, log_
     if color is None:
         color = list(mcolors.TABLEAU_COLORS.keys())
     df_len = len(df['config'].unique())
-    replace = not len(color) > df_len
-    chosen_colors = np.random.choice(color, replace=replace, size=df_len)
+
+    if isinstance(color, str):
+        cmap = plt.get_cmap(color)
+        chosen_colors = [cmap(i/df_len) for i in range(df_len)]
+    else:
+        chosen_colors = itertools.cycle(color)
 
     kwargs = {'figsize': (9 * len(layouts), 7), 'nrows': 1, 'ncols': len(layouts), **kwargs}
 

--- a/batchflow/utils.py
+++ b/batchflow/utils.py
@@ -153,10 +153,10 @@ def show_research(df, layouts=None, titles=None, average_repetitions=False, log_
     rolling_window : int of sequence of ints, optional
         Size of rolling window.
     color: str or sequence of matplotlib.colors, optional
-        If str, should be a name of matplotlib colormap, 
+        If str, should be a name of matplotlib colormap,
         colors for plots will be selected from that colormap.
-        If sequence of colors, they will be used for plots, 
-        if sequence length is less, than number of lines to plot, 
+        If sequence of colors, they will be used for plots,
+        if sequence length is less, than number of lines to plot,
         colors will be repeated in cycle
         If None (default), `mcolors.TABLEAU_COLORS` sequence is used
     kwargs:


### PR DESCRIPTION
This PR removes random colour choice in `show_research`. This ensures consistent colour coding in successive plots using same data.

This PR also introduces another option to select colours for plots by providing a mathplotlib colormap name