### PR TITLE
Fix pylint

### DIFF
--- a/.github/workflows/status.yml
+++ b/.github/workflows/status.yml
@@ -23,10 +23,7 @@ jobs:
       run: pip3 install -U pylint
 
     - name: Check pylint 
-      #run: pylint -rn --rcfile pylintrc batchflow  UNCOMMENT WHEN TORCH FIX PYLINT  
-      run: |
-        pylint -rn --rcfile pylintrc batchflow --ignore=torch
-        pylint -rn --rcfile pylintrc batchflow/models/torch --disable=abstract-method,missing-function-docstring
+      run: pylint -rn --rcfile pylintrc batchflow
 
     - name: Run tests
       if: always()

--- a/.github/workflows/status.yml
+++ b/.github/workflows/status.yml
@@ -22,8 +22,11 @@ jobs:
     - name: Update pylint
       run: pip3 install -U pylint
 
-    - name: Check pylint
-      run: pylint -rn --rcfile pylintrc batchflow
+    - name: Check pylint 
+      #run: pylint -rn --rcfile pylintrc batchflow  UNCOMMENT WHEN TORCH FIX PYLINT  
+      run: |
+        pylint -rn --rcfile pylintrc batchflow --ignore=torch
+        pylint -rn --rcfile pylintrc batchflow/models/torch --disable=abstract-method,missing-function-docstring
 
     - name: Run tests
       if: always()

--- a/batchflow/batch.py
+++ b/batchflow/batch.py
@@ -644,8 +644,8 @@ class Batch(metaclass=MethodsTransformingMeta):
         elif isinstance(src, FilesIndex):
             try:
                 file_name = src.get_fullpath(ix)
-            except KeyError:
-                raise KeyError("File {} is not indexed in the received index".format(ix))
+            except KeyError as e:
+                raise KeyError("File {} is not indexed in the received index".format(ix)) from e
 
         elif src is None:
             file_name = self.index.get_fullpath(ix)
@@ -733,7 +733,7 @@ class Batch(metaclass=MethodsTransformingMeta):
             try:
                 item = tuple(data[i] for i in components)
             except Exception as e:
-                raise KeyError('Cannot find components in corresponfig file', e)
+                raise KeyError('Cannot find components in corresponfig file', file_name) from e
         return item
 
     @inbatch_parallel('indices', target='f')

--- a/batchflow/batch_image.py
+++ b/batchflow/batch_image.py
@@ -4,7 +4,7 @@ import warnings
 from numbers import Number
 
 import numpy as np
-from skimage.transform import resize
+from skimage.transform import resize # pylint: disable=unused-import
 import scipy.ndimage
 
 import PIL

--- a/batchflow/dataset.py
+++ b/batchflow/dataset.py
@@ -75,6 +75,7 @@ class Dataset(Baseset):
         self._attrs = None
         kwargs['_copy'] = kwargs.get('_copy', copy)
         self.n_splits = None
+        self.train, self.test = None, None
 
         cv_kwargs = {item: kwargs.pop(item) for item in ['method', 'n_splits', 'shuffle'] if item in kwargs}
         if cv_kwargs.get('n_splits') is not None:

--- a/batchflow/dataset.py
+++ b/batchflow/dataset.py
@@ -75,7 +75,6 @@ class Dataset(Baseset):
         self._attrs = None
         kwargs['_copy'] = kwargs.get('_copy', copy)
         self.n_splits = None
-        self.train, self.test = None, None
 
         cv_kwargs = {item: kwargs.pop(item) for item in ['method', 'n_splits', 'shuffle'] if item in kwargs}
         if cv_kwargs.get('n_splits') is not None:
@@ -331,6 +330,7 @@ class Dataset(Baseset):
             print(dataset.test.cv1.indices) # [4, 5, 6]
             print(dataset.test.cv2.indices) # [7, 8, 9]
         """
+        # pylint: disable=access-member-before-definition
         if self.n_splits is not None:
             for i in range(self.n_splits):
                 cv_attr = 'cv'+str(i)

--- a/batchflow/decorators.py
+++ b/batchflow/decorators.py
@@ -141,9 +141,9 @@ def inbatch_parallel(init, post=None, target='threads', _use_self=None, **dec_kw
             if isinstance(init, str):
                 try:
                     init_fn = getattr(self, init)
-                except AttributeError:
+                except AttributeError as e:
                     raise ValueError("init should refer to a method or property of the class", type(self).__name__,
-                                     "returning the list of arguments")
+                                     "returning the list of arguments") from e
             elif callable(init):
                 init_fn = init
             else:
@@ -153,8 +153,8 @@ def inbatch_parallel(init, post=None, target='threads', _use_self=None, **dec_kw
                 if isinstance(post, str):
                     try:
                         post_fn = getattr(self, post)
-                    except AttributeError:
-                        raise ValueError("post should refer to a method of the class", type(self).__name__)
+                    except AttributeError as e:
+                        raise ValueError("post should refer to a method of the class", type(self).__name__) from e
                 elif callable(post):
                     post_fn = post
                 else:

--- a/batchflow/dsindex.py
+++ b/batchflow/dsindex.py
@@ -235,15 +235,16 @@ class DatasetIndex(Baseset):
         else:
             order = np.arange(len(self))
 
+        # pylint: disable=attribute-defined-outside-init
         if valid_share > 0:
             validation_pos = order[:valid_share]
-            setattr(self, 'validation', self.create_subset(self.subset_by_pos(validation_pos)))
+            self.validation = self.create_subset(self.subset_by_pos(validation_pos))
         if test_share > 0:
             test_pos = order[valid_share : valid_share + test_share]
-            setattr(self, 'test', self.create_subset(self.subset_by_pos(test_pos)))
+            self.test = self.create_subset(self.subset_by_pos(test_pos))
         if train_share > 0:
             train_pos = order[valid_share + test_share:]
-            setattr(self, 'validation', self.create_subset(self.subset_by_pos(train_pos)))
+            self.train = self.create_subset(self.subset_by_pos(train_pos))
 
     def shuffle(self, shuffle, iter_params=None):
         """ Permute indices

--- a/batchflow/dsindex.py
+++ b/batchflow/dsindex.py
@@ -31,6 +31,7 @@ class DatasetIndex(Baseset):
         super().__init__(*args, **kwargs)
         self._pos = self.build_pos()
         self._random_state = None
+        self.train, self.test, self.validation = None, None, None
 
     @classmethod
     def from_index(cls, *args, **kwargs):

--- a/batchflow/dsindex.py
+++ b/batchflow/dsindex.py
@@ -31,7 +31,6 @@ class DatasetIndex(Baseset):
         super().__init__(*args, **kwargs)
         self._pos = self.build_pos()
         self._random_state = None
-        self.train, self.test, self.validation = None, None, None
 
     @classmethod
     def from_index(cls, *args, **kwargs):
@@ -238,13 +237,13 @@ class DatasetIndex(Baseset):
 
         if valid_share > 0:
             validation_pos = order[:valid_share]
-            self.validation = self.create_subset(self.subset_by_pos(validation_pos))
+            setattr(self, 'validation', self.create_subset(self.subset_by_pos(validation_pos)))
         if test_share > 0:
             test_pos = order[valid_share : valid_share + test_share]
-            self.test = self.create_subset(self.subset_by_pos(test_pos))
+            setattr(self, 'test', self.create_subset(self.subset_by_pos(test_pos)))
         if train_share > 0:
             train_pos = order[valid_share + test_share:]
-            self.train = self.create_subset(self.subset_by_pos(train_pos))
+            setattr(self, 'validation', self.create_subset(self.subset_by_pos(train_pos)))
 
     def shuffle(self, shuffle, iter_params=None):
         """ Permute indices

--- a/batchflow/models/sklearn.py
+++ b/batchflow/models/sklearn.py
@@ -75,7 +75,7 @@ class SklearnModel(BaseModel):
         else:
             raise ValueError("Scikit-learn estimator does not exist. Check your config for 'estimator'.")
 
-    def train(self, X, y, *args, **kwargs):
+    def train(self, x, y, *args, **kwargs):
         """ Train the model with the data provided
 
         Parameters
@@ -91,11 +91,11 @@ class SklearnModel(BaseModel):
         For more details and other parameters look at the documentation for the estimator used.
         """
         if hasattr(self.estimator, 'partial_fit'):
-            self.estimator.partial_fit(X, y, *args, **kwargs)
+            self.estimator.partial_fit(x, y, *args, **kwargs)
         else:
-            self.estimator.fit(X, y, *args, **kwargs)
+            self.estimator.fit(x, y, *args, **kwargs)
 
-    def predict(self, X, *args, **kwargs):
+    def predict(self, x, *args, **kwargs):
         """ Predict with the data provided
 
         Parameters
@@ -112,4 +112,4 @@ class SklearnModel(BaseModel):
         array
             Predicted value per sample, shape (n_samples,)
         """
-        return self.estimator.predict(X, *args, **kwargs)
+        return self.estimator.predict(x, *args, **kwargs)

--- a/batchflow/models/tf/linknet.py
+++ b/batchflow/models/tf/linknet.py
@@ -62,6 +62,7 @@ class LinkNet(EncoderDecoder):
     """
     @classmethod
     def default_config(cls):
+        """ Define model defaults. See :meth: `~.TFModel.default_config` """
         config = super().default_config()
 
         config['initial_block'] += dict(layout='cnap', filters=64, kernel_size=7, strides=2,

--- a/batchflow/models/tf/vnet.py
+++ b/batchflow/models/tf/vnet.py
@@ -54,6 +54,7 @@ class VNet(EncoderDecoder):
     """
     @classmethod
     def default_config(cls):
+        """ Define model defaults. See :meth: `~.TFModel.default_config` """
         config = super().default_config()
 
         config['initial_block'] += dict(layout='cna Rcna+', kernel_size=5, filters=16)

--- a/batchflow/models/torch/base.py
+++ b/batchflow/models/torch/base.py
@@ -287,7 +287,6 @@ class TorchModel(BaseModel):
     """
     def __init__(self, config=None):
         self.full_config = Config(config)
-        self.config = Config(config)
         self.train_lock = threading.Lock()
 
         self.input_names = None
@@ -309,12 +308,7 @@ class TorchModel(BaseModel):
                          'model',
                          'train_steps', 'sync_counter', 'microbatch']
 
-        load = self.config.get('load')
-        build = self.config.get('build', default=load is None)
-        if load:
-            self.load(**load)
-        if build:
-            self.build()
+        super().__init__(config)
 
     def reset(self):
         """ Allows to recreate model from scratch. """

--- a/batchflow/models/torch/optimizers/radam.py
+++ b/batchflow/models/torch/optimizers/radam.py
@@ -58,7 +58,7 @@ class RAdam(Optimizer):
                     param['buffer'] = [[None, None, None] for _ in range(10)]
         defaults = dict(lr=lr, betas=betas, eps=eps, weight_decay=weight_decay,
                         buffer=[[None, None, None] for _ in range(10)])
-        super(RAdam, self).__init__(params, defaults)
+        super().__init__(params, defaults)
 
     def step(self, closure=None):
         """Performs a single optimization step.

--- a/batchflow/opensets/base.py
+++ b/batchflow/opensets/base.py
@@ -23,9 +23,21 @@ class Openset(Dataset):
         return None
 
     def download(self, path):
-        """ Download a dataset from the source web-site """
+        """ Download a dataset from the source web-site.
+
+        Returns
+        -------
+        tuple of np.arrays or None
+            Preloaded data components, i.e. images and labels. Return None in case using FilesIndex.
+        DatasetIndex or FilesIndex
+            An index for the dataset.
+        DatasetIndex or FilesIndex or None
+            An index for the train part of the dataset. Return None if there is no train/test split.
+        DatasetIndex or FilesIndex or None
+            An index for the test part of the dataset. Return None if there is no train/test split.
+        """
         _ = path
-        return None
+        return None, None, None, None
 
     def _infer_train_test_index(self, train_len, test_len):
         total_len = train_len + test_len

--- a/batchflow/opensets/coco.py
+++ b/batchflow/opensets/coco.py
@@ -24,9 +24,6 @@ class BaseCOCO(ImagesOpenset):
     TRAIN_IMAGES_URL = 'http://images.cocodataset.org/zips/train2017.zip'
     TEST_IMAGES_URL = 'http://images.cocodataset.org/zips/val2017.zip'
 
-    def __init__(self, *args, preloaded=None, **kwargs):
-        super().__init__(*args, preloaded=preloaded, **kwargs)
-
     def _rgb_images_paths(self, path):
         """Find RGB images(avoid grayscale) in the folder and return their paths. """
         return  [filename for filename in glob(path + '/*') if Image.open(filename).mode == 'RGB']

--- a/batchflow/research/executable.py
+++ b/batchflow/research/executable.py
@@ -193,8 +193,8 @@ class Executable:
         if self.pipeline is not None:
             try:
                 batch = self.pipeline.next_batch()
-            except StopIteration:
-                raise PipelineStopIteration('{} was stopped'.format(self.name))
+            except StopIteration as e:
+                raise PipelineStopIteration('{} was stopped'.format(self.name)) from e
         else:
             raise TypeError("Executable should be pipeline, not a function")
         return batch
@@ -219,8 +219,8 @@ class Executable:
         if self.root_pipeline is not None:
             try:
                 batch = self.root_pipeline.next_batch()
-            except StopIteration:
-                raise PipelineStopIteration('{} was stopped'.format(self.name))
+            except StopIteration as e:
+                raise PipelineStopIteration('{} was stopped'.format(self.name)) from e
         else:
             raise TypeError("Executable should have root pipeline")
         return batch

--- a/batchflow/tests/assemble_test.py
+++ b/batchflow/tests/assemble_test.py
@@ -25,7 +25,6 @@ def test_handle_exceptions():
     assert 'Could not assemble the batch' in str(err.value)
 
 
-# pylint: disable=bad-whitespace
 @pytest.mark.parametrize('all_results, kwargs, res', [
     ([0, 1],           dict(dst='c1'),         dict(c1=[0, 1], c2=None)),
     ([[0, 2], [1, 3]], dict(dst=['c1', 'c2']), dict(c1=[0, 1], c2=[2, 3])),

--- a/batchflow/tests/named_expr_test.py
+++ b/batchflow/tests/named_expr_test.py
@@ -1,4 +1,4 @@
-# pylint: disable=redefined-outer-name, missing-docstring, bad-continuation
+# pylint: disable=redefined-outer-name, missing-docstring
 import sys
 from contextlib import ExitStack as does_not_raise
 


### PR DESCRIPTION
This PR fixes pylint output in the latest docker image analysiscenter1/ds-py3. 

A lot of `missing-function-docstring` and `abstract-method` warnings happened in `batchflow/models/torch` folder we cant fix, because they occur on the torch side. They are fixing [this](https://github.com/pytorch/pytorch/issues/42305) and [this](https://github.com/pytorch/pytorch/issues/43057). 

So we can:
1.  Close eyes on this warnings.
2.  Temporary set additional restrictions for pylint for `torch` folder only like its currently done. 

@roman-kh