### PR TITLE
Default timeout for Research is None; RC can be without name

### DIFF
--- a/batchflow/research/distributor.py
+++ b/batchflow/research/distributor.py
@@ -28,7 +28,7 @@ class _DummyBar:
 
 class Distributor:
     """ Distributor of jobs between workers. """
-    def __init__(self, n_iters, workers, devices, worker_class=None, timeout=5, trials=2, logger=None):
+    def __init__(self, n_iters, workers, devices, worker_class=None, timeout=None, trials=2, logger=None):
         """
         Parameters
         ----------

--- a/batchflow/research/named_expr.py
+++ b/batchflow/research/named_expr.py
@@ -24,12 +24,11 @@ class REU(ResearchNamedExpression): # ResearchExecutableUnit
             _experiment = experiment
         else:
             _experiment = [experiment]
-        if self.name is not None:
-            res = [item[self.name] for item in _experiment]
-            if len(_experiment) == 1:
-                return res[0]
-            return res
-        return experiment
+        name = self.name if self.name is not None else list(_experiment[0].keys())[0]
+        res = [item[name] for item in _experiment]
+        if len(_experiment) == 1:
+            return res[0]
+        return res
 
 class RP(REU): # ResearchPipeline
     """ NamedExpression for Pipeline in Research """
@@ -59,7 +58,7 @@ class RI(ResearchNamedExpression): # ResearchIteration
 
 class RC(REU): # ResearchConfig
     """ NamedExpression for Config of the ExecutableUnit """
-    def __init__(self, name):
+    def __init__(self, name=None):
         super().__init__(name=name)
 
     def get(self, **kwargs):

--- a/batchflow/research/research.py
+++ b/batchflow/research/research.py
@@ -37,7 +37,7 @@ class Research:
         self.devices = None
         self.domain = None
         self.n_iters = None
-        self.timeout = 5
+        self.timeout = None
         self.n_configs = None
         self.n_reps = None
         self.n_configs = None
@@ -314,7 +314,7 @@ class Research:
         return Results(self.name, *args, **kwargs)
 
     def run(self, n_iters=None, workers=1, branches=1, name=None,
-            bar=False, devices=None, worker_class=None, timeout=5, trials=2):
+            bar=False, devices=None, worker_class=None, timeout=None, trials=2):
         """ Run research.
 
         Parameters

--- a/batchflow/research/workers.py
+++ b/batchflow/research/workers.py
@@ -111,7 +111,7 @@ class Worker:
                                 if self.timeout is not None and (time.time() - last_update_time.value) / 60 > self.timeout:
                                     p = psutil.Process(pid)
                                     p.terminate()
-                                    message = 'Job {} [{}] failed in {}'.format(job[0], pid, self.worker_name)
+                                    message = 'Job {} [{}] failed in {} because of timeout'.format(job[0], pid, self.worker_name)
                                     self.logger.info(message)
                                     final_signal.exception = TimeoutError(message)
                                     results.put(copy(final_signal))

--- a/batchflow/research/workers.py
+++ b/batchflow/research/workers.py
@@ -15,7 +15,7 @@ class Worker:
     Worker get queue of jobs, pop one job and execute it in subprocess. That subprocess
     call init, main and post class methods.
     """
-    def __init__(self, devices, worker_name=None, worker_config=None, timeout=5, trials=2, logger=None):
+    def __init__(self, devices, worker_name=None, worker_config=None, timeout=None, trials=2, logger=None):
         """
         Parameters
         ----------
@@ -107,14 +107,15 @@ class Worker:
                                 signal = feedback_queue.get(timeout=1)
                             except EmptyException:
                                 signal = None
-                            if signal is None and (time.time() - last_update_time.value) / 60 > self.timeout:
-                                p = psutil.Process(pid)
-                                p.terminate()
-                                message = 'Job {} [{}] failed in {}'.format(job[0], pid, self.worker_name)
-                                self.logger.info(message)
-                                final_signal.exception = TimeoutError(message)
-                                results.put(copy(final_signal))
-                                break
+                            if signal is None:
+                                if self.timeout is not None and (time.time() - last_update_time.value) / 60 > self.timeout:
+                                    p = psutil.Process(pid)
+                                    p.terminate()
+                                    message = 'Job {} [{}] failed in {}'.format(job[0], pid, self.worker_name)
+                                    self.logger.info(message)
+                                    final_signal.exception = TimeoutError(message)
+                                    results.put(copy(final_signal))
+                                    break
                             if signal is not None and signal.done:
                                 finished = True
                                 final_signal = signal


### PR DESCRIPTION
The previous default value for timeout (5 minutes) in Research doesn't allow to execute massive tasks in callables.
Now by default timeout is None.

RC (ResearchConfig) named expression can be used without the specification of the executable unit.
