### PR TITLE
Torch improvements

### DIFF
--- a/batchflow/models/tf/layers/conv_block.py
+++ b/batchflow/models/tf/layers/conv_block.py
@@ -298,7 +298,7 @@ class BaseConvBlock:
         'R': 'residual_start',
         'A': 'residual_bilinear_additive',
         '+': 'residual_end',
-        '.': 'residual_end',
+        '|': 'residual_end',
         '*': 'residual_end',
         '&': 'residual_end',
     }
@@ -351,7 +351,7 @@ class BaseConvBlock:
         })
 
     SKIP_LETTERS = ['R', 'A', 'B']
-    COMBINE_LETTERS = ['+', '*', '.', '&']
+    COMBINE_LETTERS = ['+', '*', '|', '&']
 
     def __init__(self, layout='',
                  filters=0, kernel_size=3, strides=1, dilation_rate=1, depth_multiplier=1,

--- a/batchflow/models/tf/layers/core.py
+++ b/batchflow/models/tf/layers/core.py
@@ -173,7 +173,7 @@ class Combine(Layer):
         return Combine.sum([gated, clamped])
 
     OPS = {
-        concat: ['concat', 'cat', '.'],
+        concat: ['concat', 'cat', '|'],
         sum: ['sum', 'plus', '+'],
         mul: ['multi', 'mul', '*'],
         mean: ['avg', 'mean', 'average'],

--- a/batchflow/models/torch/base.py
+++ b/batchflow/models/torch/base.py
@@ -270,7 +270,7 @@ class TorchModel(BaseModel, VisualizationMixin):
         'loss', 'optimizer', 'decay', 'decay_step',
         'sync_counter', 'microbatch',
         'iteration', 'iter_info', 'lr_list', 'syncs', 'decay_iters',
-        '_loss_list', 'loss_list'
+        '_loss_list', 'loss_list',
     ]
 
     def __init__(self, config=None):
@@ -927,7 +927,7 @@ class TorchModel(BaseModel, VisualizationMixin):
                     p.grad /= sync_frequency
 
             # Store learning rate: once per sync
-            # Note: we do it before decay, so it is actual used LR on this iteration
+            # Note: we do it before decay, so it is actual LR used on this iteration
             self.lr_list.append([group['lr'] for group in self.optimizer.param_groups])
 
             # Update weights and remove grads

--- a/batchflow/models/torch/blocks.py
+++ b/batchflow/models/torch/blocks.py
@@ -207,7 +207,7 @@ class DenseBlock(ConvBlock):
             strides = [1, strides]
             filters = [growth_rate * bottleneck, filters]
 
-        layout = 'R' + layout + '.'
+        layout = 'R' + layout + '|'
         super().__init__(layout=layout, kernel_size=kernel_size, strides=strides, dropout_rate=dropout_rate,
                          filters=filters, n_repeats=num_layers, inputs=inputs, **kwargs)
 

--- a/batchflow/models/torch/layers/conv_block.py
+++ b/batchflow/models/torch/layers/conv_block.py
@@ -180,7 +180,7 @@ class BaseConvBlock(nn.ModuleDict):
         'B': 'branch',
         'R': 'branch', # stands for `R`esidual
         '+': 'branch_end',
-        '.': 'branch_end',
+        '|': 'branch_end',
         '*': 'branch_end',
         '&': 'branch_end',
         '>': 'increase_dim',
@@ -247,7 +247,7 @@ class BaseConvBlock(nn.ModuleDict):
 
 
     BRANCH_LETTERS = ['R', 'B']
-    COMBINE_LETTERS = ['+', '*', '.', '&']
+    COMBINE_LETTERS = ['+', '*', '|', '&']
 
     def __init__(self, inputs=None, layout='',
                  filters=0, kernel_size=3, strides=1, dilation_rate=1, depth_multiplier=1,

--- a/batchflow/models/torch/layers/resize.py
+++ b/batchflow/models/torch/layers/resize.py
@@ -82,7 +82,7 @@ class Combine(nn.Module):
 
     op : str or callable
         If callable, then operation to be applied to the list of inputs.
-        If 'concat', 'cat', '.', then inputs are concated along channels axis.
+        If 'concat', 'cat', '|', then inputs are concated along channels axis.
         If 'sum', '+', then inputs are summed.
         If 'mul', '*', then inputs are multiplied.
         If 'avg', then inputs are averaged.
@@ -141,7 +141,7 @@ class Combine(nn.Module):
         return Combine.sum([weighted, skip])
 
     OPS = {
-        concat: ['concat', 'cat', '.'],
+        concat: ['concat', 'cat', '|'],
         sum: ['sum', 'plus', '+'],
         mul: ['multi', 'mul', '*'],
         mean: ['average', 'avg', 'mean'],

--- a/batchflow/models/torch/visualization.py
+++ b/batchflow/models/torch/visualization.py
@@ -12,15 +12,15 @@ import torch
 class VisualizationMixin:
     """ Collection of visualization (both textual and graphical) tools for a :class:`~.torch.TorchModel`. """
     # Textual visualization of the model
-    def information(self, config=True, devices=True, train_steps=True, model=False, misc=False):
+    def information(self, config=True, devices=True, model=False, misc=True):
         """ Show information about model configuration, used devices, train steps and more. """
-        print(self._information(config=config, devices=devices, train_steps=train_steps, model=model, misc=misc))
+        print(self._information(config=config, devices=devices, model=model, misc=misc))
 
     def info(self):
         """ Return the info message with default parameters. """
-        return self.information()
+        return self._information()
 
-    def _information(self, config=True, devices=True, train_steps=True, model=False, misc=False):
+    def _information(self, config=True, devices=True, model=False, misc=True):
         """ Create information string. """
         message = ''
         template = '\n##### {}:\n'
@@ -34,10 +34,6 @@ class VisualizationMixin:
             message += f'Leading device is {self.device}\n'
             if self.devices:
                 message += '\n'.join([f'Device {i} is {d}' for i, d in enumerate(self.devices)])
-
-        if train_steps:
-            message += template.format('Train steps')
-            message += pformat(self.train_steps) + '\n'
 
         if model:
             message += template.format('Model')
@@ -57,16 +53,10 @@ class VisualizationMixin:
                 num_params = sum(p.numel() for p in self.model.parameters() if p.requires_grad)
                 message += f'\nTotal number of parameters in model: {num_params}'
 
-            iters = {key: value.get('iter', 0) for key, value in self.train_steps.items()}
-            message += f'\nTotal number of passed training iterations: {sum(list(iters.values()))}\n'
-            if len(iters) > 1:
-                message += 'Number of training iterations for individual train steps:'
-                message += pformat(iters) + '\n'
+            message += f'\nTotal number of passed training iterations: {self.iteration}\n'
 
             message += template.format('Last iteration params')
-            iter_info = {**self.iter_info}
-            iter_info.pop('lr') #TODO : make a separate container for LR
-            message += pformat(iter_info)
+            message += pformat(self.iter_info)
         return message
 
     def short_repr(self):
@@ -106,7 +96,7 @@ class VisualizationMixin:
     def show_lr(self):
         """ Plot graph of learning rate over iterations. """
         plt.figure(figsize=(8, 6))
-        plt.plot(self.iter_info['lr'])
+        plt.plot(self.lr_list)
 
         plt.title('Learning rate', fontsize=18)
         plt.xlabel('Iterations', fontsize=12)

--- a/batchflow/tests/notebooks/torch_test.ipynb
+++ b/batchflow/tests/notebooks/torch_test.ipynb
@@ -279,6 +279,9 @@
     "             'units': [256, 512]},\n",
     "    'head': {'layout': 'faf',\n",
     "             'units': [600, 10]},\n",
+    "    'microbatch': 16,\n",
+    "    'decay': {'name': 'exp', 'gamma': 0.5, 'frequency': 10}\n",
+    "#     'loss': {'name': 'ce', 'weight': 'dynamic'}\n",
     "}\n",
     "\n",
     "\n",
@@ -320,7 +323,7 @@
     "    'initial_block': {'layout': 'fafaf', 'units': [128, 256, 10]},\n",
     "    'order': ['initial_block', ('ib_2', 'initial_block', TorchModel.initial_block)],\n",
     "    'loss': ['ce', 'ce'],\n",
-    "    'decay': 'exp',\n",
+    "    'decay': {'name': 'exp', 'frequency': 1, 'gamma': 0.999},\n",
     "    'n_iters': 25,\n",
     "    'train_steps': {'ts_1': {}, 'ts_2': {}},\n",
     "}\n",
@@ -365,25 +368,11 @@
     "    'initial_block/filters': 6,\n",
     "    'body/encoder/blocks/n_reps': [1, 1, 2, 1],\n",
     "    'body/encoder/blocks/bottleneck': False,\n",
+    "    'body/encoder/blocks/filters': 'int(same * 2)',\n",
     "    'body/encoder/blocks/attention': 'se',\n",
     "}\n",
     "\n",
     "ppl = run('classification', ResNet, config, 'resnet with config')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2020-02-14T12:41:43.661416Z",
-     "start_time": "2020-02-14T12:41:43.591313Z"
-    },
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "ppl.m('MODEL').info"
    ]
   },
   {
@@ -528,10 +517,11 @@
    "source": [
     "config = {\n",
     "    'body/encoder/num_stages': 2,\n",
-    "    'body/embedding': {'base': ASPP, 'pyramid': (2, 4, 8)},\n",
+    "    'body/encoder/blocks/filters': 'same * 4',\n",
+    "    'body/embedding': {'layout': 'cna', 'filters': 32, 'pyramid': (2, 4, 8)},\n",
     "}\n",
     "\n",
-    "ppl = run('segmentation', EncoderDecoder, config, 'unet-like with ASPP')"
+    "ppl = run('segmentation', EncoderDecoder, config, 'unet-like with ASPP', batch_size=64, n_iters=200)"
    ]
   },
   {
@@ -541,8 +531,7 @@
     "ExecuteTime": {
      "end_time": "2020-02-10T14:49:48.472236Z",
      "start_time": "2020-02-10T14:49:47.070986Z"
-    },
-    "scrolled": true
+    }
    },
    "outputs": [],
    "source": [
@@ -593,10 +582,30 @@
     "config = {\n",
     "    'body/encoder/base_model': ResNet18,\n",
     "    'body/encoder/base_model_kwargs/blocks/filters': 7, \n",
-    "    'body/decoder/blocks/filters': 'same//4'\n",
+    "    'body/decoder/blocks/filters': 'same//4',\n",
+    "    'decay': {'name': 'exp', 'gamma': 0.8, 'frequency': 10}\n",
     "}\n",
     "\n",
-    "ppl = run('segmentation', EncoderDecoder, config, 'encoder-decoder with resnet18 backbone')"
+    "ppl = run('segmentation', EncoderDecoder, config, 'encoder-decoder with resnet18 backbone',\n",
+    "          batch_size=64, n_iters=200)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ppl.m('MODEL').show_lr()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ppl.m('MODEL').short_repr()"
    ]
   },
   {
@@ -606,27 +615,11 @@
     "ExecuteTime": {
      "end_time": "2020-02-14T12:41:11.908921Z",
      "start_time": "2020-02-14T12:41:11.875720Z"
-    },
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "ppl.m('MODEL').info"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2020-02-14T12:36:52.505206Z",
-     "start_time": "2020-02-14T12:36:52.447265Z"
     }
    },
    "outputs": [],
    "source": [
-    "# ppl.m('MODEL').set_debug_mode(True)\n",
-    "ppl.m('MODEL').model"
+    "ppl.m('MODEL').information(misc=True)"
    ]
   }
  ],
@@ -646,7 +639,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.6.9"
   },
   "varInspector": {
    "cols": {
@@ -679,5 +672,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/batchflow/tests/torch_models_test.py
+++ b/batchflow/tests/torch_models_test.py
@@ -55,11 +55,11 @@ class Test_models:
         Finally, we assert that our modification was actually applied to a model by attempting
         to build and train it with a small batch.
     """
-    @pytest.mark.parametrize('decay', [None, 'exp'])
+    @pytest.mark.parametrize('decay', [None, {'name': 'exp', 'frequency': 25}])
     def test_data_format(self, model, model_setup_images_clf, pipeline, decay):
         """ We can explicitly pass 'data_format' to inputs or common."""
         dataset, model_config = model_setup_images_clf('channels_first')
-        model_config.update(decay=decay, n_iters=25)
+        model_config.update(decay=decay)
         config = {'model_class': model, 'model_config': model_config}
         test_pipeline = (pipeline << dataset) << config
         batch = test_pipeline.next_batch(2, n_epochs=None)


### PR DESCRIPTION
This PR removes the `train_steps` construction from `TorchModel`. Along the way, I've changed inner storages for iteration info and sync counters: now they are all integers and zero-based, which makes them easier to understand.

Also, I changed the `'.'` operation letter for concatenation to `'|'`, as dots are not allowed in the module name by `Pytorch` convention.

Moreover, I've made sure that all the tests are working: one of them was failing due to the new (one-year-old) syntax of `decays`. 