### PR TITLE
fix colors in show_research

### DIFF
--- a/batchflow/utils.py
+++ b/batchflow/utils.py
@@ -183,7 +183,7 @@ def show_research(df, layouts=None, titles=None, average_repetitions=False, log_
         cmap = plt.get_cmap(color)
         chosen_colors = [cmap(i/df_len) for i in range(df_len)]
     else:
-        chosen_colors = itertools.cycle(color)
+        chosen_colors = list(itertools.islice(itertools.cycle(color), df_len))
 
     kwargs = {'figsize': (9 * len(layouts), 7), 'nrows': 1, 'ncols': len(layouts), **kwargs}
 


### PR DESCRIPTION
Make colors consistent across different plots in research results


Before fix (Note different line colors for same configs):
![before](https://user-images.githubusercontent.com/7520522/100889270-ffd1ae00-34c7-11eb-9307-8c733839725b.png)
after fix:
 ![after](https://user-images.githubusercontent.com/7520522/100889291-02cc9e80-34c8-11eb-9cdd-b85bec45b169.png)
