### PR TITLE
Pass microbatches on device individually

### DIFF
--- a/batchflow/models/torch/base.py
+++ b/batchflow/models/torch/base.py
@@ -881,7 +881,9 @@ class TorchModel(BaseModel, VisualizationMixin):
                     self.classes = self.target_shape[1]
 
             self.build_config()
-            self._build([item[:2] for item in split_inputs[0]])
+            build_inputs = [item[:2] for item in split_inputs[0]]
+            build_inputs = self.transfer_to_device(build_inputs)
+            self._build(build_inputs)
             self.model_lock.release()
 
         self.model.train()

--- a/batchflow/models/torch/base.py
+++ b/batchflow/models/torch/base.py
@@ -881,6 +881,7 @@ class TorchModel(BaseModel, VisualizationMixin):
                     self.classes = self.target_shape[1]
 
             self.build_config()
+            # Can use the first two items to build model: no need for the whole tensor
             build_inputs = [item[:2] for item in split_inputs[0]]
             build_inputs = self.transfer_to_device(build_inputs)
             self._build(build_inputs)

--- a/batchflow/models/torch/layers/conv_block.py
+++ b/batchflow/models/torch/layers/conv_block.py
@@ -242,7 +242,6 @@ class BaseConvBlock(nn.ModuleDict):
         'D': 'd',
         'n': 'd',
         'N': 'b',
-        'X': 'b',
         })
 
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+github_checks:
+    annotations: false


### PR DESCRIPTION
This PR proposes to split `TorchModel._fill_input` method, which formerly did the following:

- parsed positional and named arguments into model `inputs` and `targets`
- transfered them to `model.device`

into two methods: `parse_inputs` and `transfer_to_device`. That allows for finer control over when data is copied onto GPU, which is necessary to pass individual microbatches at a time (not the whole training batch).

It also allows for more options for passed data: now model can be trained with `np.ndarray`'s, `torch.Tensor`'s and `cupy.ndarray`'s. 