### PR TITLE
Torch improvements

### DIFF
--- a/batchflow/__init__.py
+++ b/batchflow/__init__.py
@@ -16,7 +16,7 @@ from .notifier import Notifier
 from .named_expr import NamedExpression, B, C, F, L, V, M, D, R, W, P, I
 from .dsindex import DatasetIndex, FilesIndex
 from .decorators import action, inbatch_parallel, parallel, any_action_failed, mjit, deprecated, apply_parallel
-from .exceptions import SkipBatchException, EmptyBatchSequence
+from .exceptions import SkipBatchException, EmptyBatchSequence, StopPipeline
 from .sampler import Sampler, ConstantSampler, NumpySampler, HistoSampler, ScipySampler
 from .utils import save_data_to
 from .utils_notebook import in_notebook, get_notebook_path, get_notebook_name, pylint_notebook

--- a/batchflow/models/torch/base.py
+++ b/batchflow/models/torch/base.py
@@ -206,6 +206,9 @@ class TorchModel(BaseModel, VisualizationMixin):
         If True, then each gradient is scaled according to its own L2 norm.
         If False, then one common gradient norm is computed and used as a scaler for all gradients.
 
+    callbacks : sequence of `:class:callbacks.BaseCallback`
+        Callbacks to call at the end of each training iteration.
+
     order : sequence
         Defines sequence of network blocks in the architecture. Default is initial_block -> body -> head.
         Each element of the sequence must be either a string, a tuple or a dict.
@@ -669,7 +672,7 @@ class TorchModel(BaseModel, VisualizationMixin):
         if isinstance(decay, (tuple, list)):
             decays = decay
         else:
-            decays = [(decay, kwargs)]
+            decays = [(decay, kwargs)] if decay else []
 
         self.decay, self.decay_step = [], []
 

--- a/batchflow/models/torch/base.py
+++ b/batchflow/models/torch/base.py
@@ -1187,8 +1187,7 @@ class TorchModel(BaseModel, VisualizationMixin):
 
                 if targets is not None:
                     targets = self.transfer_to_device(targets)
-                    loss = self.loss(predictions, targets)
-                    output_container['loss'] = loss
+                    output_container['loss'] = self.loss(predictions, targets)
 
             config = self.full_config
             additional_outputs = self.output(inputs=predictions, predictions=config['predictions'],

--- a/batchflow/models/torch/base.py
+++ b/batchflow/models/torch/base.py
@@ -100,18 +100,18 @@ class TorchModel(BaseModel, VisualizationMixin):
         If `inputs` is specified with all the required shapes, then it serves as size of batch dimension during
         placeholder (usually np.ndarrays with zeros) creation. Default value is 2.
 
-    loss : str, dict, list
+    loss : str, dict
         Loss function, might be defined in multiple formats.
 
         If str, then short ``name``.
         If dict, then ``{'name': name, **kwargs}``.
-        If list, then each item is a dict of format described above.
 
         Name must be one of:
             - short name (e.g. ``'mse'``, ``'ce'``, ``'l1'``, ``'cos'``, ``'hinge'``,
               ``'huber'``, ``'logloss'``, ``'dice'``)
             - a class name from `torch losses <https://pytorch.org/docs/stable/nn.html#loss-functions>`_
               (e.g. ``'PoissonNLL'`` or ``'TripletMargin'``)
+            - an instance of `:class:torch.nn.Module`
             - callable
 
         Examples:
@@ -120,7 +120,6 @@ class TorchModel(BaseModel, VisualizationMixin):
         - ``{'loss': {'name': 'KLDiv', 'reduction': 'none'}}``
         - ``{'loss': {'name': MyCustomLoss, 'epsilon': 1e-6}}``
         - ``{'loss': my_custom_loss_fn}``
-        - ``{'loss': ['dice', 'bce']}``
 
     optimizer : str, dict
         Optimizer, might be defined in multiple formats.
@@ -623,7 +622,7 @@ class TorchModel(BaseModel, VisualizationMixin):
 
     # Create training procedure(s): loss, optimizer, decay
     def make_loss(self, loss, **kwargs):
-        """ !!. """
+        """ Set model loss. Changes the `loss` attribute. """
         loss_fn = None
         # Parse `loss` to actual module
         if isinstance(loss, str):
@@ -654,7 +653,7 @@ class TorchModel(BaseModel, VisualizationMixin):
         self.loss = loss_fn
 
     def make_optimizer(self, optimizer, **kwargs):
-        """ !!. """
+        """ Set model optimizer. Changes the `optimizer` attribute. """
         # Choose the optimizer
         if callable(optimizer) or isinstance(optimizer, type):
             pass
@@ -666,7 +665,7 @@ class TorchModel(BaseModel, VisualizationMixin):
         self.optimizer = optimizer(self.model.parameters(), **kwargs)
 
     def make_decay(self, decay, optimizer=None, **kwargs):
-        """ !!. """
+        """ Set model decay. Changes the `decay` and `decay_step` attribute. """
         if isinstance(decay, (tuple, list)):
             decays = decay
         else:

--- a/batchflow/models/torch/base.py
+++ b/batchflow/models/torch/base.py
@@ -185,7 +185,7 @@ class TorchModel(BaseModel, VisualizationMixin):
         If True, then stats can be accessed via `profile_info` attribute or :meth:`.show_profile_info` method.
 
     amp : bool
-        Whether to use automated mixed precision during model training.
+        Whether to use automated mixed precision during model training. Default is True.
 
     sync_frequency : int
         How often to apply accumulated gradients to the weights. Default value is to apply them after each batch.
@@ -316,8 +316,8 @@ class TorchModel(BaseModel, VisualizationMixin):
         self.decay = None
         self.decay_step = None
 
-        self.scaler = None
         self.amp = True
+        self.scaler = None
 
         self.callbacks = []
 
@@ -372,7 +372,7 @@ class TorchModel(BaseModel, VisualizationMixin):
 
         # If the inputs are set in config with their shapes we can build right away
         if self.input_shapes:
-            self._build_model()
+            self._build()
 
 
     # Create config of model creation: combine the external and default ones
@@ -560,7 +560,7 @@ class TorchModel(BaseModel, VisualizationMixin):
 
 
     # Chain multiple building blocks to create model
-    def _build_model(self, inputs=None):
+    def _build(self, inputs=None):
         config = self.full_config
         order = config.get('order')
 
@@ -720,7 +720,7 @@ class TorchModel(BaseModel, VisualizationMixin):
             self.decay_step.append(step_params)
 
 
-    # Use external model
+    # Use an external model
     def set_model(self, model):
         """ Set the underlying model to a supplied one and update training infrastructure. """
         self.model = model
@@ -971,7 +971,7 @@ class TorchModel(BaseModel, VisualizationMixin):
                 self.build_config()
                 build_inputs = [item[:2] for item in split_inputs[0]]
                 build_inputs = self.transfer_to_device(build_inputs)
-                self._build_model(build_inputs)
+                self._build(build_inputs)
 
             self.model.train()
 

--- a/batchflow/models/torch/callbacks/plateau.py
+++ b/batchflow/models/torch/callbacks/plateau.py
@@ -2,7 +2,7 @@
 import numpy as np
 
 from .base import BaseCallback
-from ....exceptions import StopPipeline
+from ....batchflow.exceptions import StopPipeline
 
 
 

--- a/batchflow/models/torch/callbacks/plateau.py
+++ b/batchflow/models/torch/callbacks/plateau.py
@@ -2,7 +2,7 @@
 import numpy as np
 
 from .base import BaseCallback
-from ....batchflow.exceptions import StopPipeline
+from ....exceptions import StopPipeline
 
 
 

--- a/batchflow/models/torch/visualization.py
+++ b/batchflow/models/torch/visualization.py
@@ -146,6 +146,7 @@ class VisualizationMixin:
 
         # Parse inputs to model, run model
         inputs, _ = self._make_prediction_inputs(*args, targets=None, feed_dict=feed_dict, **kwargs)
+        inputs = self.transfer_to_device(inputs)
         self.model.eval()
         with torch.no_grad():
             self.model(inputs)
@@ -248,6 +249,7 @@ class VisualizationMixin:
         """
         extractor = LayerExtractor(layer)
         inputs, targets = self._make_prediction_inputs(*args, targets=targets, feed_dict=feed_dict, **kwargs)
+        inputs = self.transfer_to_device(inputs)
 
         self.model.eval()
         prediction = self.model(inputs)
@@ -256,7 +258,7 @@ class VisualizationMixin:
             gradient = self._fill_value(gradient_mode)
         elif 'targ' in gradient_mode:
             gradient = targets
-        elif 'oh' in gradient_mode:
+        elif 'onehot' in gradient_mode:
             gradient = torch.zeros_like(prediction)[0:1]
             cam_class = cam_class or np.argmax(prediction.detach().cpu().numpy()[0])
             gradient[0][cam_class] = 1

--- a/batchflow/notifier.py
+++ b/batchflow/notifier.py
@@ -344,7 +344,7 @@ class Notifier:
             if isinstance(source, (str, NamedExpression)):
                 value = container['data'][iteration]
                 if isinstance(value, (int, float, np.signedinteger, np.floating)):
-                    desc = f'{name}={value:<6.6}' if isinstance(value, float) else f'{name}={value:<6}'
+                    desc = f'{name}={value:<6.6f}' if isinstance(value, (float, np.floating)) else f'{name}={value:<6}'
                     description.append(desc)
         return ';   '.join(description)
 

--- a/batchflow/pipeline.py
+++ b/batchflow/pipeline.py
@@ -1300,6 +1300,10 @@ class Pipeline:
                 notifier.update(pipeline=self, batch=batch)
             except SkipBatchException:
                 skip_batch = True
+            except StopPipeline:
+                self._prefetch_queue.task_done()
+                self._batch_queue.put(None)
+                break
             except Exception:   # pylint: disable=broad-except
                 exc = future.exception()
                 print("Exception in a thread:", exc)

--- a/batchflow/tests/notebooks/torch_test.ipynb
+++ b/batchflow/tests/notebooks/torch_test.ipynb
@@ -28,7 +28,8 @@
     "from batchflow import *\n",
     "from batchflow.opensets import MNIST\n",
     "from batchflow.models.torch import *\n",
-    "from batchflow.models.torch.layers import *"
+    "from batchflow.models.torch.layers import *\n",
+    "from batchflow.models.torch.callbacks import ReduceLROnPlateau, EarlyStopping"
    ]
   },
   {
@@ -56,7 +57,7 @@
     "\n",
     "if __name__ == '__main__':\n",
     "    MICROBATCH = None\n",
-    "    DEVICE = None\n",
+    "    DEVICE = 'gpu:0'\n",
     "    BAR = 'n'\n",
     "    PLOT = True\n",
     "\n",
@@ -170,15 +171,16 @@
    },
    "outputs": [],
    "source": [
-    "def run(task, model_class, config, description, batch_size=BATCH_SIZE, n_iters=N_ITERS):\n",
+    "def run(task, model_class, config, description, batch_size=BATCH_SIZE, n_iters=N_ITERS, **kwargs):\n",
     "    if task == 'classification':\n",
     "        pipeline_config = get_classification_config(model_class, config)\n",
     "    elif task == 'segmentation':\n",
     "        pipeline_config = get_segmentation_config(model_class, config)\n",
     "\n",
     "    train_pipeline = get_pipeline(pipeline_config) << mnist.train\n",
-    "    _ = train_pipeline.run(batch_size, n_iters=n_iters, bar=BAR,\n",
-    "                           bar_desc=W(V('loss_history')[-1].format('Loss is {:7.7}')))\n",
+    "    _ = train_pipeline.run(batch_size, n_iters=n_iters,\n",
+    "                           bar={'bar': 'n', 'monitors': 'loss_history'},\n",
+    "                           **kwargs)\n",
     "    \n",
     "    print('{} {} is done'.format(task, description))\n",
     "    return train_pipeline"
@@ -322,7 +324,7 @@
     "config = {\n",
     "    'initial_block': {'layout': 'fafaf', 'units': [128, 256, 10]},\n",
     "    'order': ['initial_block', ('ib_2', 'initial_block', TorchModel.initial_block)],\n",
-    "    'loss': ['ce', 'ce'],\n",
+    "    'loss': 'ce',\n",
     "    'decay': {'name': 'exp', 'frequency': 1, 'gamma': 0.999},\n",
     "    'n_iters': 25,\n",
     "    'train_steps': {'ts_1': {}, 'ts_2': {}},\n",
@@ -387,7 +389,7 @@
    "outputs": [],
    "source": [
     "ppl = run('classification', ResNet18, {}, 'resnet18')\n",
-    "ppl = run('classification', SEResNeXt18, {}, 'SE-resneXt18')\n",
+    "# ppl = run('classification', SEResNeXt18, {}, 'SE-resneXt18')\n",
     "# ppl = run('classification', DenseNet121, {}, 'DenseNet121')"
    ]
   },
@@ -569,25 +571,78 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Misc"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2020-02-10T14:49:55.529346Z",
-     "start_time": "2020-02-10T14:49:53.953549Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "config = {\n",
-    "    'body/encoder/base_model': ResNet18,\n",
-    "    'body/encoder/base_model_kwargs/blocks/filters': 7, \n",
-    "    'body/decoder/blocks/filters': 'same//4',\n",
-    "    'decay': {'name': 'exp', 'gamma': 0.8, 'frequency': 10}\n",
+    "    'amp': False\n",
     "}\n",
     "\n",
-    "ppl = run('segmentation', EncoderDecoder, config, 'encoder-decoder with resnet18 backbone',\n",
-    "          batch_size=64, n_iters=200)"
+    "ppl = run('classification', ResNet34, config, 'resnet34', batch_size=64, n_iters=200)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "config = {\n",
+    "    'amp': True # default\n",
+    "}\n",
+    "\n",
+    "ppl = run('classification', ResNet34, config, 'resnet34', batch_size=64, n_iters=200)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "config = {\n",
+    "    'amp': True,\n",
+    "    'sam_rho': 0.05,\n",
+    "}\n",
+    "\n",
+    "ppl = run('classification', ResNet34, config, 'resnet34', batch_size=64, n_iters=200)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "config = {\n",
+    "    'callbacks': [\n",
+    "    ReduceLROnPlateau(patience=20, cooldown=20, min_delta=0.1, factor=0.9),\n",
+    "    EarlyStopping(patience=100, min_delta=0.01)\n",
+    "    ],\n",
+    "    'decay': {'name': 'exp', 'gamma': 0.8, 'frequency': 20},\n",
+    "}\n",
+    "\n",
+    "with Monitor() as monitor:\n",
+    "    ppl = run('classification', ResNet34, config, 'resnet34', batch_size=64, n_iters=200)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.plot(ppl.m('MODEL').loss_list)\n",
+    "plt.grid()"
    ]
   },
   {
@@ -597,6 +652,15 @@
    "outputs": [],
    "source": [
     "ppl.m('MODEL').show_lr()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "monitor.visualize()"
    ]
   },
   {
@@ -621,6 +685,23 @@
    "source": [
     "ppl.m('MODEL').information(misc=True)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "config = {\n",
+    "    'callbacks': [\n",
+    "    ReduceLROnPlateau(patience=20, cooldown=20, min_delta=0.1, factor=0.9),\n",
+    "    EarlyStopping(patience=100, min_delta=0.01)\n",
+    "    ],\n",
+    "    'decay': {'name': 'exp', 'gamma': 0.8, 'frequency': 20},\n",
+    "}\n",
+    "\n",
+    "ppl = run('classification', ResNet34, config, 'resnet34', batch_size=64, n_iters=200, prefetch=5)"
+   ]
   }
  ],
  "metadata": {
@@ -639,7 +720,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.6.10"
   },
   "varInspector": {
    "cols": {

--- a/batchflow/tests/notebooks/torch_test.ipynb
+++ b/batchflow/tests/notebooks/torch_test.ipynb
@@ -641,6 +641,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "test(ppl)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "plt.plot(ppl.m('MODEL').loss_list)\n",
     "plt.grid()"
    ]


### PR DESCRIPTION
This PR proposes to:

- use the `padding` parameter of `Conv#D` layers instead of manual `F.pad` in the majority of the cases: if the padding is either one `int`, a tuple of `ints` (i.e. `(2, 3)`), a tuple of tuples of `ints` with the same values (i.e. `((2, 2), (3, 3))`)
- `lock` the entire `train` method
- add `AMP` - automated mixed precision in `train`, which provides 15-30% speed-up depending on the model architecture
- make methods for creating `loss`, `optimizer`, `decay` public, change their signatures and make them modify corresponding attributes in-place
- remove the possibility to pass a list of losses into the model configuration
- add `set_model` method to set external `Torch` module as the `model`, while also updating `optimizer` and `decay`
- add some of the missing docstrings