### PR TITLE
Fixes for torch model and notifier

### DIFF
--- a/batchflow/models/torch/base.py
+++ b/batchflow/models/torch/base.py
@@ -186,6 +186,7 @@ class TorchModel(BaseModel, VisualizationMixin):
 
     amp : bool
         Whether to use automated mixed precision during model training and inference. Default is True.
+        The output type of predictions remains float32.
 
     sync_frequency : int
         How often to apply accumulated gradients to the weights. Default value is to apply them after each batch.
@@ -1186,7 +1187,7 @@ class TorchModel(BaseModel, VisualizationMixin):
 
                 if self.amp:
                     if isinstance(predictions, (tuple, list)):
-                        predictions = [p.float() for p in predictions]
+                        predictions = type(predictions)(p.float() for p in predictions)
                     else:
                         predictions = predictions.float()
                 output_container['predictions'] = predictions

--- a/batchflow/models/torch/base.py
+++ b/batchflow/models/torch/base.py
@@ -1183,6 +1183,12 @@ class TorchModel(BaseModel, VisualizationMixin):
                 output_container = {}
                 inputs = self.transfer_to_device(inputs)
                 predictions = self.model(inputs)
+
+                if self.amp:
+                    if isinstance(predictions, (tuple, list)):
+                        predictions = [p.float() for p in predictions]
+                    else:
+                        predictions = predictions.float()
                 output_container['predictions'] = predictions
 
                 if targets is not None:

--- a/batchflow/models/torch/visualization.py
+++ b/batchflow/models/torch/visualization.py
@@ -259,7 +259,7 @@ class VisualizationMixin:
         prediction = self.model(inputs)
 
         if isinstance(gradient_mode, np.ndarray):
-            gradient = self._fill_value(gradient_mode)
+            gradient = self.transfer_to_device(gradient_mode)
         elif 'targ' in gradient_mode:
             gradient = targets
         elif 'onehot' in gradient_mode:

--- a/batchflow/notifier.py
+++ b/batchflow/notifier.py
@@ -25,6 +25,7 @@ class DummyBar:
         self.args, self.kwargs = args, kwargs
 
         self.n = 0
+        self.desc = ''
         self.start_t = time()
 
     def update(self, n):
@@ -37,8 +38,8 @@ class DummyBar:
     def sp(self, *args, **kwargs):
         _ = args, kwargs
 
-    def set_description(self, *args, **kwargs):
-        _ = args, kwargs
+    def set_description(self, description):
+        self.desc = description
 
     def close(self):
         pass


### PR DESCRIPTION
The main contribution of this PR is the conversion of predicted arrays back to `float32` precision, even with `amp` turned on