### PR TITLE
Fix in ResBlock convs parameters counter

### DIFF
--- a/batchflow/models/torch/blocks.py
+++ b/batchflow/models/torch/blocks.py
@@ -103,7 +103,7 @@ class ResBlock(ConvBlock):
     """
     def __init__(self, inputs=None, layout='cnacn', filters='same', kernel_size=3, strides=1,
                  downsample=False, bottleneck=False, attention=None, groups=1, op='+a', n_reps=1, **kwargs):
-        num_convs = sum(letter in CONV_LETTERS for letter in layout)
+        num_convs = sum(letter in CONV_LETTERS for letter in layout) + sum(letter in CONV_LETTERS for letter in op)
 
         filters = [filters] * num_convs if isinstance(filters, (int, str)) else filters
         filters = [safe_eval(item, get_num_channels(inputs)) if isinstance(item, str) else item


### PR DESCRIPTION
ResBlock didn't work correctly if there were convolutions in the 'op'.