### PR TITLE
Add run_notebook function

### DIFF
--- a/batchflow/__init__.py
+++ b/batchflow/__init__.py
@@ -20,7 +20,7 @@ from .exceptions import SkipBatchException, EmptyBatchSequence, StopPipeline
 from .sampler import Sampler, ConstantSampler, NumpySampler, HistoSampler, ScipySampler
 from .utils import save_data_to, read_data_from
 from .utils_random import make_rng, make_seed_sequence, spawn_seed_sequence
-from .utils_notebook import in_notebook, get_notebook_path, get_notebook_name, pylint_notebook,\
+from .utils_notebook import in_notebook, get_notebook_path, get_notebook_name, run_notebook, pylint_notebook,\
                             get_available_gpus, set_gpus
 
 

--- a/batchflow/utils_notebook.py
+++ b/batchflow/utils_notebook.py
@@ -120,9 +120,9 @@ def run_notebook(path, nb_kwargs=None, insert_pos=1, kernel_name=None, timeout=-
         raise FileNotFoundError(f'Path {path} not found.')
 
     if save_ipynb and out_path_ipynb is None:
-        out_path_ipynb = path.split('.')[0] + suffix + '.ipynb'
+        out_path_ipynb = os.path.splitext(path)[0] + suffix + '.ipynb'
     if save_html and out_path_html is None:
-        out_path_html = path.split('.')[0] + suffix + '.html'
+        out_path_html = os.path.splitext(path)[0] + suffix + '.html'
 
     # Execution arguments
     execute_kwargs = execute_kwargs or {}

--- a/batchflow/utils_notebook.py
+++ b/batchflow/utils_notebook.py
@@ -2,10 +2,12 @@
 import os
 import re
 import json
+import time
 
 import numpy as np
 
-# Additionally imports 'requests`, 'ipykernel`, `notebook`, `nbconvert`, `pylint` and `nvidia_smi`, if needed
+# Additionally imports 'requests`, 'ipykernel`, `notebook`, `nbconvert`, `pylint`,
+#                      'nbconvert', 'IPython' and `nvidia_smi`, if needed
 
 
 def in_notebook():
@@ -55,6 +57,132 @@ def get_notebook_name():
         return None
 
     return os.path.splitext(get_notebook_path())[0].split('/')[-1]
+
+
+
+def run_notebook(path, nb_kwargs=None, insert_pos=1, kernel_name=None, timeout=-1,
+                 working_dir='./', execute_kwargs=None,
+                 save_ipynb=True, out_path_ipynb=None, save_html=False, out_path_html=None, suffix='_out',
+                 add_timestamp=True, hide_input=False, display_links=True, raise_exception=False, return_nb=False):
+    """ Run a notebook and save the output.
+    Additionally, allows to pass `nb_kwargs` arguments, that are used for notebook execution. Under the hood,
+    we place all of them into a separate cell, inserted in the notebook; hence, all of the keys must be valid Python
+    names, and values should be valid for re-creating objects.
+    Heavily inspired by https://github.com/tritemio/nbrun.
+
+    Parameters
+    ----------
+    path : str
+        Path to the notebook to execute.
+    nb_kwargs : dict, optional
+        Additional arguments for notebook execution. Converted into cell of variable assignments and inserted
+        into the notebook on `insert_pos` place.
+    insert_pos : int
+        Position to insert the cell with argument assignments into the notebook.
+    kernel_name : str, optional
+        Name of the kernel to execute the notebook.
+    timeout : int
+        Maximum execution time for each cell. -1 means no constraint.
+    working_dir : str
+        The working folder of starting the kernel.
+    execute_kwargs : dict, optional
+        Other parameters of `:class:ExecutePreprocessor`.
+    save_ipynb : bool
+        Whether to save the output .ipynb file.
+    out_path_ipynb : str, optional
+        Path to save the output .ipynb file. If not provided and `save_ipynb` is set to True, we add `suffix` to `path`.
+    save_html : bool
+        Whether to convert the output notebook to .html.
+    out_path_html : str, optional
+        Path to save the output .html file.
+        If not provided and `save_html` is set to True, we add `suffix` to `path` and change extension.
+    suffix : str
+        Appended to output file names if paths are not explicitly provided.
+    add_timestamp : bool
+        Whether to add cell with execution information in the beginning of the output notebook.
+    hide_input : bool
+        Whether to hide the code cells in the output notebook.
+    display_links : bool
+        Whether to display links to the output notebook and html at execution.
+    raise_exception
+        Whether to re-raise exceptions from the notebook.
+    return_nb
+        Whether to return the notebook object from this function.
+    """
+    # pylint: disable=bare-except, lost-exception
+    from IPython.display import display, FileLink
+    import nbformat
+    from nbconvert.preprocessors import ExecutePreprocessor
+    from nbconvert import HTMLExporter
+
+    # Prepare paths
+    if not os.path.exists(path):
+        raise FileNotFoundError(f'Path {path} not found.')
+
+    if save_ipynb and out_path_ipynb is None:
+        out_path_ipynb = path.split('.')[0] + suffix + '.ipynb'
+    if save_html and out_path_html is None:
+        out_path_html = path.split('.')[0] + suffix + '.html'
+
+    # Execution arguments
+    execute_kwargs = execute_kwargs or {}
+    execute_kwargs.update(timeout=timeout)
+    if kernel_name:
+        execute_kwargs.update(kernel_name=kernel_name)
+    executor = ExecutePreprocessor(**execute_kwargs)
+
+    # Read the master notebook, prepare and insert kwargs cell
+    notebook = nbformat.read(path, as_version=4)
+    if hide_input:
+        notebook["metadata"].update({"hide_input": True})
+    if nb_kwargs:
+        header = '# Cell inserted during automated execution.'
+        lines = (f"{key} = {repr(value)}"
+                 for key, value in nb_kwargs.items())
+        code = '\n'.join(lines)
+        code_cell = '\n'.join((header, code))
+        notebook['cells'].insert(insert_pos, nbformat.v4.new_code_cell(code_cell))
+
+    # Execute the notebook
+    start_time = time.time()
+    try:
+        executor.preprocess(notebook, {'metadata': {'path': working_dir}})
+    except:
+        # Execution failed, print a message and re-raise
+        msg = ('Error executing the notebook "%s".\n'
+               'Notebook arguments: %s\n\n'
+               'See notebook "%s" for the traceback.' %
+               (path, str(nb_kwargs), out_path_ipynb))
+        print(msg)
+
+        if raise_exception:
+            raise
+    finally:
+        # Add execution info
+        if add_timestamp:
+            duration = int(time.time() - start_time)
+            timestamp = (f'**Executed:** {time.ctime(start_time)}<br>'
+                         f'**Duration:** {duration} seconds.<br>'
+                         f'**Autogenerated from:** [{path}]\n\n---')
+            timestamp_cell = nbformat.v4.new_markdown_cell(timestamp)
+            notebook['cells'].insert(0, timestamp_cell)
+
+        # Save the executed notebook/HTML to disk
+        if save_ipynb:
+            nbformat.write(notebook, out_path_ipynb)
+            if display_links:
+                display(FileLink(out_path_ipynb))
+        if save_html:
+            html_exporter = HTMLExporter()
+            body, _ = html_exporter.from_notebook_node(notebook)
+            with open(out_path_html, 'w') as f:
+                f.write(body)
+            if display_links:
+                display(FileLink(out_path_html))
+
+        if return_nb:
+            return notebook
+        return None
 
 
 def pylint_notebook(path=None, options='', printer=print, ignore_comments=True, ignore_codes=None,


### PR DESCRIPTION
`run_notebook` allows to execute external `.ipynb` file and save the output as a separate notebook, as well as to convert it to HTML for convenience. 