### PR TITLE
Fix default retrieval for `C`

### DIFF
--- a/batchflow/named_expr.py
+++ b/batchflow/named_expr.py
@@ -519,7 +519,7 @@ class C(PipelineNamedExpression):
     def get(self, **kwargs):
         """ Return a value of a pipeline config """
         name, pipeline, _ = self._get_params(**kwargs)
-        config = pipeline.config or {}
+        config = pipeline.config or Config()
 
         if name is None:
             return config


### PR DESCRIPTION
`C.get` fails to retrieve the default value for named expression when pipeline config is empty.

This happens due to a call on line `528`, where keyword argument `default` is passed.
Since the default python `dict` takes no keyword arguments, such call leads to `TypeError`.