### PR TITLE
Update activation.py

### DIFF
--- a/batchflow/models/torch/layers/activation.py
+++ b/batchflow/models/torch/layers/activation.py
@@ -100,7 +100,7 @@ class Activation(nn.Module):
             # check if activation has `in_place` parameter
             has_inplace = 'inplace' in inspect.getfullargspec(activation).args
             if has_inplace:
-                kwargs['inplace'] = True
+                kwargs['inplace'] = kwargs.get('inplace', True)
             self.activation = activation(*args, **kwargs)
 
         # A ready to use nn.Module or callable


### PR DESCRIPTION
Force inplace breaks 'silu' activation with an obscure error message.

Using in-place operations is also discuraged in docs: https://pytorch.org/docs/stable/notes/autograd.html#in-place-operations-with-autograd


We need at least a possibility to set `inplace=False` in activation config