### PR TITLE
Pass `targets` to `parse_inputs`

### DIFF
--- a/batchflow/models/torch/base.py
+++ b/batchflow/models/torch/base.py
@@ -1263,8 +1263,8 @@ class TorchModel(BaseModel, VisualizationMixin):
         if feed_dict:
             if targets is not None:
                 if 'targets' in feed_dict.keys():
-                    warnings.warn("`targets` already present in `feed_dict`," +
-                                  " so those passed as keyword arg won't be used")
+                    warnings.warn("`targets` is already present in `feed_dict`, " +
+                                  "so targets passed as a keyword arg won't be used")
                 else:
                     feed_dict['targets'] = targets
             *inputs, targets = self.parse_inputs(*args, **feed_dict)


### PR DESCRIPTION
When calling `predict` for a multi-input  model, `targets` paramter can be processed incorrectly.

Ex,, `.predict_model('mdl', inp1=B('traces'), inp2=B('coords'), targets=B('tgt_trace'), ...)`

in _make_prediction_inputs(self, *args, targets=None, feed_dict=None, **kwargs)

all kwargs except `targets` go to feed_dict variable, so in current version `targets` is not passed to `parce_inputs`, and it breaks


Hot fix is inside this PR

But maybe it would be better to detangle inputs processing in _make_prediction_inputs

