### PR TITLE
L expression

### DIFF
--- a/batchflow/__init__.py
+++ b/batchflow/__init__.py
@@ -13,7 +13,7 @@ from .dataset import Dataset
 from .pipeline import Pipeline
 from .monitor import *
 from .notifier import Notifier
-from .named_expr import NamedExpression, B, BA, C, F, V, M, D, R, W, P, PP, I
+from .named_expr import NamedExpression, B, L, C, F, V, M, D, R, W, P, PP, I, eval_expr
 from .dsindex import DatasetIndex, FilesIndex
 from .decorators import action, inbatch_parallel, parallel, any_action_failed, mjit, deprecated, apply_parallel
 from .exceptions import SkipBatchException, EmptyBatchSequence, StopPipeline

--- a/batchflow/named_expr.py
+++ b/batchflow/named_expr.py
@@ -448,8 +448,10 @@ class L(B):
 
     Note
     ----
-    ``L('comp').images`` is equivalent to the list comprehension ``[val.images for val in batch.comp]``.
+    ``L('comp').attr`` is equivalent to the list comprehension ``[val.attr for val in batch.comp]``.
     ``L('comp')[item]`` is equivalent to the list comprehension ``[val[item] for val in batch.comp]``.
+
+    Any chains of consecutive calls of items or attribures like ``L('comp').attr[item].attr2 ... `` are also allowed.
     """
     def __init__(self, name=None, mode='w', **kwargs):
         super().__init__(name, mode)
@@ -471,6 +473,19 @@ class L(B):
         if 'item' in self.kwargs:
             return [v[self.kwargs['item']] for v in name]
         return name
+
+    def assign(self, value, **kwargs):
+        """ Assign a value to batch component or item/attribute stored in the batch component """
+        name, batch, _ = self._get_params(**kwargs)
+
+        if 'attr' in self.kwargs:
+            [setattr(n, self.kwargs['attr'], v) for n, v in zip(name, value)]
+        elif 'item' in self.kwargs:
+            for n, v in zip(name, value):
+                n[self.kwargs['item']] = v
+        else:
+            # If value is assigned to the object itself it will be rewritten with `value`.
+            setattr(batch, name, value)
 
     def __getattr__(self, name):
         return L(self, attr=name)

--- a/batchflow/named_expr.py
+++ b/batchflow/named_expr.py
@@ -479,7 +479,8 @@ class L(B):
         name, batch, _ = self._get_params(**kwargs)
 
         if 'attr' in self.kwargs:
-            [setattr(n, self.kwargs['attr'], v) for n, v in zip(name, value)]
+            for n, v in zip(name ,value):
+                setattr(n, self.kwargs['attr'], v)
         elif 'item' in self.kwargs:
             for n, v in zip(name, value):
                 n[self.kwargs['item']] = v

--- a/batchflow/named_expr.py
+++ b/batchflow/named_expr.py
@@ -117,7 +117,7 @@ OPERATIONS_SIGNS = {
     '__and__': '&', '__or__': ' |', '__xor__': '^',
     '__lt__': '<', '__le__': '<=', '__gt__': '>', '__ge__': '>=',
     '__eq__': '==', '__ne__': '!=',
-    '__is__': 'is', '__is_not__': 'is not',
+    '__is__': 'is', '__is_not__': 'is not', '__not__': 'not '
 }
 
 def add_ops(cls):
@@ -471,7 +471,7 @@ class L(B):
         if 'attr' in self.kwargs:
             return [getattr(v, self.kwargs['attr']) for v in name]
         if 'item' in self.kwargs:
-            return [v[self.kwargs['item']] for v in name]
+            return [v[eval_expr(self.kwargs['item'], **kwargs)] for v in name]
         return name
 
     def assign(self, value, **kwargs):
@@ -483,7 +483,7 @@ class L(B):
                 setattr(n, self.kwargs['attr'], v)
         elif 'item' in self.kwargs:
             for n, v in zip(name, value):
-                n[self.kwargs['item']] = v
+                n[eval_expr(self.kwargs['item'], **kwargs)] = v
         else:
             # If value is assigned to the object itself it will be rewritten with `value`.
             setattr(batch, name, value)

--- a/batchflow/tests/named_expr_test.py
+++ b/batchflow/tests/named_expr_test.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 
 sys.path.append('..')
-from batchflow import (B, BA, C, D, F, V, R, P, PP, I, Dataset, Pipeline, Batch,
+from batchflow import (B, L, C, D, F, V, R, P, PP, I, Dataset, Pipeline, Batch,
                        apply_parallel, inbatch_parallel, action)
 
 
@@ -200,7 +200,7 @@ def test_d(size, n_splits):
 
 
 #--------------------
-#         BA
+#         L
 #--------------------
 
 class SomeObject:
@@ -216,21 +216,20 @@ class SomeObject:
         return self.item[key]
 
     def __setitem__(self, key, value):
-        print(key, value)
         self.item[key] = np.atleast_2d(value)
 
 @pytest.mark.parametrize('batch_length', [1, 2])
-def test_ba(batch_length):
-    """Test behaivour of BA named expression for all sorts of read-write options.
+def test_l(batch_length):
+    """Test L expression for all sorts of read-write options.
 
     batch_length
         The length of array with components.
     """
     pipeline = (Dataset(1).p
         .add_components('object', [SomeObject()]*batch_length)
-        .update(BA('object').attr, BA('object').battr)
-        .update(BA('object')['item_0'], [10]*batch_length)
-        .update(BA('object')[['item_2', 'item_3']], BA('object')[['item_0', 'item_1']])
+        .update(L('object').attr, L('object').battr)
+        .update(L('object')['item_0'], [10]*batch_length)
+        .update(L('object')[['item_2', 'item_3']], L('object')[['item_0', 'item_1']])
     )
     batch = pipeline.next_batch(1)
     assert batch.object[0].attr == 1


### PR DESCRIPTION
This pool request provides:
* Named expression L that is aimed at working with batch components that contains a list of objects. Also, it provides to redirect calls of getitem/getattr/setitem/setattr into objects itself by writing:
   * `L('comp').attr` or `L('comp')[item]` or even `L('comp').attr1.attr2[item1].attr3 ...` etc.
* Add some operators to named expression 