### PR TITLE
Torch improvements

### DIFF
--- a/batchflow/models/base.py
+++ b/batchflow/models/base.py
@@ -6,7 +6,7 @@ class BaseModel(ABC):
 
     @property
     def default_name(self):
-        """ PLaceholder for model name. """
+        """ Placeholder for model name. """
         return self.__class__.__name__
 
     @abstractmethod
@@ -23,11 +23,11 @@ class BaseModel(ABC):
 
     @abstractmethod
     def load(self):
-        """ Load the model from dick. """
+        """ Load the model from the disc. """
 
     @abstractmethod
     def save(self):
-        """ Save the model to dick. """
+        """ Save the model to the disc. """
 
     @classmethod
     def is_model_like(cls, obj):

--- a/batchflow/models/base.py
+++ b/batchflow/models/base.py
@@ -1,99 +1,38 @@
 """ Contains a base model class"""
+from abc import ABC, abstractmethod
 
-from ..config import Config
-
-class BaseModel:
-    """ Base class for all models
-
-    Attributes
-    ----------
-    name : str
-        a model name
-    config : dict
-        configuration parameters
-
-    Notes
-    -----
-
-    **Configuration**:
-
-    * build : bool or 1 or 'first'
-        whether to build a model by calling `self.build()`. Default is True.
-        If build == 1 or 'first', then build is called before load, otherwise afterwards.
-    * load : dict
-        parameters for model loading. If present, a model will be loaded
-        by calling `self.load(**config['load'])`.
-
-    * model_class : type
-        (optional) A specific model class to instantiate the model.
-
-    """
-    def __init__(self, config=None, *args, **kwargs):
-        self.config = Config(config)
-        load = self.config.get('load')
-        build = self.config.get('build', default=load is None)
-        if not isinstance(build, bool) and build in [1, 'first']:
-            self.build(*args, **kwargs)
-            build = False
-        if load:
-            self.load(**load)
-        if build:
-            self.build(*args, **kwargs)
+class BaseModel(ABC):
+    """ Base interface for models. """
 
     @property
     def default_name(self):
-        """: str - the class name (serve as a default for a model name) """
+        """ PLaceholder for model name. """
         return self.__class__.__name__
 
-    @classmethod
-    def pop(cls, variables, config, **kwargs):
-        """ Return variables and remove them from config"""
-        return Config().pop(variables, config, **kwargs)
-
-    @classmethod
-    def get(cls, variables, default=None, config=None):
-        """ Return variables from config """
-        return Config().get(variables, default=default, config=config)
-
-    @classmethod
-    def put(cls, variable, value, config):
-        """ Put a new variable into config """
-        return Config().put(variable, value, config)
-
-    def _make_inputs(self, names=None, config=None):
-        """ Make model input data using config
-
-        Parameters
-        ----------
-        names : a sequence of str - names for input variables
-
-        Returns
-        -------
-        None or dict - where key is a variable name and a value is a corresponding variable after configuration
-        """
-        _ = names, config
-        return None
-
+    @abstractmethod
     def reset(self):
-        """ Reset the trained model to allow a new training from scratch """
-        pass
+        """ Reset the trained model to allow a new training from scratch. """
 
-    def build(self, *args, **kwargs):
-        """ Define the model """
-        _ = self, args, kwargs
+    @abstractmethod
+    def train(self):
+        """ Train the model. """
 
-    def load(self, *args, **kwargs):
-        """ Load the model """
-        _ = self, args, kwargs
+    @abstractmethod
+    def predict(self):
+        """ Make a prediction using the model.  """
 
-    def save(self, *args, **kwargs):
-        """ Save the model """
-        _ = self, args, kwargs
+    @abstractmethod
+    def load(self):
+        """ Load the model from dick. """
 
-    def train(self, *args, **kwargs):
-        """ Train the model """
-        _ = self, args, kwargs
+    @abstractmethod
+    def save(self):
+        """ Save the model to dick. """
 
-    def predict(self, *args, **kwargs):
-        """ Make a prediction using the model  """
-        _ = self, args, kwargs
+    @classmethod
+    def is_model_like(cls, obj):
+        """ Check if the `obj` provides the same interface, as required by this specification. """
+        for method in cls.__abstractmethods__:
+            if not hasattr(obj, method):
+                return False
+        return True

--- a/batchflow/models/torch/base.py
+++ b/batchflow/models/torch/base.py
@@ -930,7 +930,7 @@ class TorchModel(BaseModel, ExtractionMixin, VisualizationMixin):
         # Lock the entire method; release in any case
         try:
             if lock:
-                self.model_lock.acquire() #pylint: disable=consider-using-with
+                self.model_lock.acquire()
             self.last_iteration_info = {}
 
             # Parse inputs and targets: always a list
@@ -1215,7 +1215,7 @@ class TorchModel(BaseModel, ExtractionMixin, VisualizationMixin):
         # Acquire lock; release in any case
         try:
             if lock:
-                self.model_lock.acquire() #pylint: disable=consider-using-with
+                self.model_lock.acquire()
 
             # Parse outputs: always a list
             single_output = isinstance(outputs, str)

--- a/batchflow/models/torch/base.py
+++ b/batchflow/models/torch/base.py
@@ -1101,7 +1101,7 @@ class TorchModel(BaseModel, ExtractionMixin, VisualizationMixin):
         self.last_train_info['available_outputs'] = list(output_container.keys())
 
         # Retrieve requested outputs
-        requested_outputs = self._extract_outputs(outputs, output_container)
+        requested_outputs = self.extract_outputs(outputs, output_container)
 
         # Transfer only the requested outputs to CPU
         return self.transfer_from_device(requested_outputs)

--- a/batchflow/models/torch/base.py
+++ b/batchflow/models/torch/base.py
@@ -1322,9 +1322,9 @@ class TorchModel(BaseModel, ExtractionMixin, VisualizationMixin):
         Scalar values are aggregated by `mean`, array values are concatenated along the first (batch) axis.
         """
         result = []
-        for output_name in outputs:
+        for i, _ in enumerate(outputs):
             # All tensors for current `output_name`
-            chunked_output = [chunk_outputs[output_name] for chunk_outputs in chunked_outputs]
+            chunked_output = [chunk_outputs[i] for chunk_outputs in chunked_outputs]
 
             if chunked_output[0].size != 1:
                 result.append(np.concatenate(chunked_output, axis=0))
@@ -1404,14 +1404,15 @@ class TorchModel(BaseModel, ExtractionMixin, VisualizationMixin):
 
     def extract_outputs(self, outputs, output_container):
         """ Retrieve activation data from hooks, get other requested outputs from container. """
-        requested_outputs = {}
+        requested_outputs = []
         for item in outputs:
             if isinstance(item, LayerHook):
                 item.close()
                 value = item.activation
             else:
                 value = output_container[item]
-            requested_outputs[item] = value
+
+            requested_outputs.append(value)
         return requested_outputs
 
 

--- a/batchflow/models/torch/base.py
+++ b/batchflow/models/torch/base.py
@@ -952,7 +952,7 @@ class TorchModel(BaseModel, ExtractionMixin, VisualizationMixin):
             # Split the data into `microbatch` size chunks
             (chunked_inputs, chunked_targets,
             batch_size, microbatch) = self.split_into_microbatches(inputs, targets,
-                                                                    microbatch, microbatch_drop_last)
+                                                                   microbatch, microbatch_drop_last)
 
             steps = len(chunked_inputs)
             inputs_shapes = [get_shape(item) for item in chunked_inputs[-1]]
@@ -1032,7 +1032,7 @@ class TorchModel(BaseModel, ExtractionMixin, VisualizationMixin):
         targets = self.transfer_to_device(targets)
 
         # Convert layer ids into LayerHooks
-        outputs = self._prepare_outputs(outputs)
+        outputs = self.prepare_outputs(outputs)
 
         # Compute predictions; store shapes for introspection
         with torch.cuda.amp.autocast(enabled=self.amp):

--- a/batchflow/models/torch/base.py
+++ b/batchflow/models/torch/base.py
@@ -87,7 +87,7 @@ class TorchModel(BaseModel, ExtractionMixin, OptimalBatchSizeMixin, Visualizatio
 
         - PyTorch model configuration.
             - `order` defines the sequence of blocks to build the model from. Default is initial_block -> body -> head.
-            Separation of the NN into multiple blocks is just for conveniency, so we can split
+            Separation of the NN into multiple blocks is just for convenience, so we can split
             the preprocessing, main body of the model, and postprocessing into individual parts.
             In the simplest case, each element is a string that points to other key in the config,
             which is used to create a :class:`~.torch.layers.ConvBlock`.
@@ -97,7 +97,7 @@ class TorchModel(BaseModel, ExtractionMixin, OptimalBatchSizeMixin, Visualizatio
             - `common` parameters are passed to each of the neural network parts. Default is empty.
             - `output` defines additional operations, applied to the output after loss computation.
             By default, we have `predictions`, `predictions_{i}` and `predictions_{i}_{j}` aliases.
-            Note that these do not interfere with loss computation and are here only for conveniency.
+            Note that these do not interfere with loss computation and are here only for convenience.
             - `init_weights` allows to initialize weights.
 
         - shapes info. If fully provided, used to initialize the model. If no shapes are given in the config,
@@ -120,9 +120,9 @@ class TorchModel(BaseModel, ExtractionMixin, OptimalBatchSizeMixin, Visualizatio
             - `profile` to get detailed report of model performance. Default is False.
 
         - infrastructure for training:
-            - `loss`. No default value, so this key is requiered.
+            - `loss`. No default value, so this key is required.
             - `optimizer`. Default is `Adam`.
-            ` decay`. Default is to not use learning rate decay.
+            - `decay`. Default is to not use learning rate decay.
 
 
     We recommend looking at :class:`~.torch.layers.ConvBlock` to learn about parameters for model building blocks,
@@ -211,15 +211,15 @@ class TorchModel(BaseModel, ExtractionMixin, OptimalBatchSizeMixin, Visualizatio
     # Shapes: optional
     inputs_shapes : sequence
         Shapes of the input tensors without the batch size.
-        Must be a tuple (one input) or sequence on tuples (multiple inputs) with shapes.
+        Must be a tuple (one input) or sequence of tuples (multiple inputs) with shapes.
 
     inputs_shapes : sequence
         Shapes of the target tensors without the batch size.
-        Must be a tuple (one target) or sequence on tuples (multiple targets) with shapes.
-        Available as `` parameter in the `head` block.
+        Must be a tuple (one target) or sequence of tuples (multiple targets) with shapes.
+        Available as `targets_shapes` parameter in the `head` block.
 
     classes : int or sequence of ints
-        Number of desired classes in the output tensor. Available as `` parameter in the `head` block.
+        Number of desired classes in the output tensor. Available as `classes` parameter in the `head` block.
 
     placeholder_batch_size : int
         If `inputs` is specified with all the required shapes, then it serves as size of batch dimension during
@@ -749,7 +749,7 @@ class TorchModel(BaseModel, ExtractionMixin, OptimalBatchSizeMixin, Visualizatio
             - tuple of three elements, which are name, config key and method name or callable
             - dictionary with three items, which are `block_name`, `config_name` and `method`.
 
-            The `block_name` is then used as the identifier in resulting model, i.e. `model.body`, `model.head`.
+            The `block_name` is used as the identifier in resulting model, i.e. `model.body`, `model.head`.
             The `config_name` is used to retrieve block creation parameters from config.
             The `method` is either a callable or name of the method to get from the current instance.
             Either method or callable should return an instance of nn.Module and accept block parameters.
@@ -1357,9 +1357,8 @@ class TorchModel(BaseModel, ExtractionMixin, OptimalBatchSizeMixin, Visualizatio
     def split_into_microbatches(self, inputs, targets, microbatch, drop_last):
         """ Split inputs and targets into microbatch-sized chunks. """
         # Parse microbatch size
-        if microbatch:
-            if microbatch is True:
-                microbatch = self.microbatch
+        if microbatch is True:
+            microbatch = self.microbatch
 
         # Compute batch_size and make sure it is the same for all inputs and targets
         batch_size = len(inputs[0])

--- a/batchflow/models/torch/base.py
+++ b/batchflow/models/torch/base.py
@@ -213,7 +213,7 @@ class TorchModel(BaseModel, ExtractionMixin, OptimalBatchSizeMixin, Visualizatio
         Shapes of the input tensors without the batch size.
         Must be a tuple (one input) or sequence of tuples (multiple inputs) with shapes.
 
-    inputs_shapes : sequence
+    targets_shapes : sequence
         Shapes of the target tensors without the batch size.
         Must be a tuple (one target) or sequence of tuples (multiple targets) with shapes.
         Available as `targets_shapes` parameter in the `head` block.
@@ -465,17 +465,6 @@ class TorchModel(BaseModel, ExtractionMixin, OptimalBatchSizeMixin, Visualizatio
         Don't forget to use the default config from parent class.
         """
         config = Config({
-            # Model building
-            'order': ['initial_block', 'body', 'head'],
-            'initial_block': {},
-            'body': {},
-            'head': {},
-            'common': {},
-            'placeholder_batch_size': 2,
-
-            # Additional operations to apply to model predictions
-            'output': None,
-
             # Devices and memory control
             'amp': True,
             'device': None,
@@ -483,6 +472,19 @@ class TorchModel(BaseModel, ExtractionMixin, OptimalBatchSizeMixin, Visualizatio
             'microbatch_size': False,
             'sync_frequency': 1,
             'profile': False,
+
+            # Model building
+            'order': ['initial_block', 'body', 'head'],
+            'initial_block': {},
+            'body': {},
+            'head': {},
+            'common': {},
+
+            # Additional operations to apply to model predictions
+            'output': None,
+
+            # Shapes
+            'placeholder_batch_size': 2,
 
             # Training infrastructure
             'loss': None,
@@ -626,6 +628,7 @@ class TorchModel(BaseModel, ExtractionMixin, OptimalBatchSizeMixin, Visualizatio
 
     def _unpack(self, name):
         """ Get params from config. """
+        # TODO: move all code here to make it more explicit
         unpacked = unpack_fn_from_config(name, self.config)
         if isinstance(unpacked, list):
             return {name: unpacked}
@@ -1544,7 +1547,7 @@ class TorchModel(BaseModel, ExtractionMixin, OptimalBatchSizeMixin, Visualizatio
         The model will be moved to device specified in the model config by key `device`.
         """
         _ = args
-        self.parse_devices()
+        self._parse_devices()
 
         if kwargs.get('pickle_module') is None:
             kwargs['pickle_module'] = dill

--- a/batchflow/models/torch/base.py
+++ b/batchflow/models/torch/base.py
@@ -70,7 +70,7 @@ DECAYS_DEFAULTS = {
 
 
 class TorchModel(BaseModel, ExtractionMixin, OptimalBatchSizeMixin, VisualizationMixin):
-    r""" Base class for eager Torch models.
+    """ Base class for eager Torch models.
 
     Parameters
     ----------

--- a/batchflow/models/torch/encoder_decoder.py
+++ b/batchflow/models/torch/encoder_decoder.py
@@ -203,7 +203,7 @@ class Encoder(TorchModel):
     @classmethod
     def body(cls, inputs, return_all=False, **kwargs):
         """ Make a sequential list of encoder modules. """
-        kwargs = cls.get_defaults('body', kwargs)
+        kwargs = cls.get_block_defaults('body', kwargs)
         encoder = kwargs.pop('encoder')
         layers = [('encoder', EncoderModule(inputs=inputs, return_all=return_all, **{**kwargs, **encoder}))]
         return nn.Sequential(OrderedDict(layers))
@@ -271,7 +271,7 @@ class Decoder(TorchModel):
     @classmethod
     def body(cls, inputs, **kwargs):
         """ Make a sequential list of decoder modules. """
-        kwargs = cls.get_defaults('body', kwargs)
+        kwargs = cls.get_block_defaults('body', kwargs)
         decoder = kwargs.pop('decoder')
         layers = [('decoder', DecoderModule(inputs=inputs, **{**kwargs, **decoder}))]
         return nn.Sequential(OrderedDict(layers))
@@ -279,7 +279,7 @@ class Decoder(TorchModel):
     @classmethod
     def head(cls, inputs, classes=None, **kwargs):
         """ Make network's head. If needed, apply 1x1 convolution to obtain correct output shape. """
-        kwargs = cls.get_defaults('head', kwargs)
+        kwargs = cls.get_block_defaults('head', kwargs)
         layers = []
         layer = super().head(inputs, classes=classes, **kwargs)
         if layer is not None:
@@ -430,7 +430,7 @@ class EncoderDecoder(Decoder):
     @classmethod
     def body(cls, inputs, **kwargs):
         """ Sequence of encoder, embedding and decoder. """
-        kwargs = cls.get_defaults('body', kwargs)
+        kwargs = cls.get_block_defaults('body', kwargs)
         encoder = kwargs.pop('encoder')
         embedding = kwargs.pop('embedding')
         decoder = kwargs.pop('decoder')

--- a/batchflow/models/torch/mixins.py
+++ b/batchflow/models/torch/mixins.py
@@ -145,7 +145,7 @@ class OptimalBatchSizeMixin:
     """ Compute optimal batch size for training/inference to maximize GPU memory usage.
     Works by using `train`/`predict` with different batch sizes, and measuring how much memory is taken.
     Then, we solve the system of `measured_memory = batch_size * item_size + model_size + eps` equations for both
-    `item_size` and `model_size`ю
+    `item_size` and `model_size`.
 
     For stable measurements, we make `n` iterations of `train`/`predict`, until the memory consumption stabilizes.
     """
@@ -165,7 +165,7 @@ class OptimalBatchSizeMixin:
 
             # Exit condition
             batch_size += delta_batch_size
-            if info['memory'] > 80 or batch_size > max_batch_size :
+            if info['memory'] > max_memory or batch_size > max_batch_size :
                 break
 
         # Make and solve a system of equations for `item_size`, `model_size`

--- a/batchflow/models/torch/mixins.py
+++ b/batchflow/models/torch/mixins.py
@@ -147,6 +147,7 @@ class OptimalBatchSizeMixin:
                                    start_batch_size=4, delta_batch_size=4, max_batch_size=128, max_iters=16,
                                    n=20, frequency=0.05, time_threshold=3, tail_size=20, std_threshold=0.1):
         """ !!. """
+        #pylint: disable=consider-iterating-dictionary
         table = {}
         batch_size = start_batch_size
         for _ in Notifier(pbar)(range(max_iters)):

--- a/batchflow/models/torch/mixins.py
+++ b/batchflow/models/torch/mixins.py
@@ -222,6 +222,7 @@ class OptimalBatchSizeMixin:
 
 class LayerHook:
     """ Hook to get both activations and gradients for a layer. """
+    # TODO: work out the list activations / gradients
     def __init__(self, module):
         self.activation = None
         self.gradient = None
@@ -230,17 +231,17 @@ class LayerHook:
         self.backward_handle = module.register_backward_hook(self.backward_hook)
 
     def forward_hook(self, module, input, output):
-        """ Save activations: if multi-output, the first one is saved. """
+        """ Save activations: if multi-output, the last one is saved. """
         _ = module, input
         if isinstance(output, (tuple, list)):
             output = output[-1]
         self.activation = output
 
     def backward_hook(self, module, grad_input, grad_output):
-        """ Save gradients: if multi-output, the first one is saved. """
+        """ Save gradients: if multi-output, the last one is saved. """
         _ = module, grad_input
         if isinstance(grad_output, (tuple, list)):
-            grad_output = grad_output[0]
+            grad_output = grad_output[-1]
         self.gradient = grad_output
 
     def close(self):

--- a/batchflow/models/torch/mixins.py
+++ b/batchflow/models/torch/mixins.py
@@ -27,7 +27,7 @@ def pformat(object, indent=1, width=80, depth=None, *, compact=False, sort_dicts
 class VisualizationMixin:
     """ Collection of visualization (both textual and graphical) tools for a :class:`~.torch.TorchModel`. """
     # Textual visualization of the model
-    def information(self, config=True, devices=True, model=False, misc=True):
+    def information(self, config=False, devices=True, model=False, misc=True):
         """ Show information about model configuration, used devices, train steps and more. """
         print(self._information(config=config, devices=devices, model=model, misc=misc))
 
@@ -35,7 +35,7 @@ class VisualizationMixin:
         """ Return the info message with default parameters. """
         return self._information()
 
-    def _information(self, config=True, devices=True, model=False, misc=True):
+    def _information(self, config=False, devices=True, model=False, misc=True):
         """ Create information string. """
         message = ''
         template_header = '\n\033[1m\033[4m{}:\033[0m\n'
@@ -64,9 +64,10 @@ class VisualizationMixin:
             if self.classes:
                 message += f'Number of classes: {self.classes}\n'
 
+            message += template_header.format('Model info')
             if self.model:
                 num_params = sum(p.numel() for p in self.model.parameters() if p.requires_grad)
-                message += f'\nTotal number of parameters in the model: {num_params:,}'
+                message += f'Total number of parameters in the model: {num_params:,}'
 
             message += f'\nTotal number of passed training iterations: {self.iteration}\n'
 
@@ -205,9 +206,9 @@ class OptimalBatchSizeMixin:
         with GPUMemoryMonitor(frequency=frequency) as monitor:
             for _ in range(n):
                 if method == 'train':
-                    _ = self.train(inputs=inputs, targets=targets, microbatch=False)
+                    _ = self.train(inputs=inputs, targets=targets, microbatch_size=False)
                 elif method == 'predict':
-                    _ = self.predict(inputs=inputs, microbatch=False)
+                    _ = self.predict(inputs=inputs, microbatch_size=False)
 
         # Check if the measurement is stable. If so, return the value and confidence
         data = monitor.data

--- a/batchflow/models/torch/visualization.py
+++ b/batchflow/models/torch/visualization.py
@@ -67,8 +67,13 @@ class VisualizationMixin:
 
             message += f'\nTotal number of passed training iterations: {self.iteration}\n'
 
-            message += template_header.format('Last iteration params')
-            message += pformat(self.last_iteration_info, sort_dicts=False) + '\n'
+            if self.last_train_info:
+                message += template_header.format('Last train iteration info')
+                message += pformat(self.last_train_info, sort_dicts=False) + '\n'
+
+            if self.last_predict_info:
+                message += template_header.format('Last predict iteration info')
+                message += pformat(self.last_predict_info, sort_dicts=False) + '\n'
         return message[1:-1]
 
     def short_repr(self):

--- a/batchflow/models/torch/visualization.py
+++ b/batchflow/models/torch/visualization.py
@@ -63,7 +63,7 @@ class VisualizationMixin:
 
             if self.model:
                 num_params = sum(p.numel() for p in self.model.parameters() if p.requires_grad)
-                message += f'\nTotal number of parameters in the model: {num_params}'
+                message += f'\nTotal number of parameters in the model: {num_params:,}'
 
             message += f'\nTotal number of passed training iterations: {self.iteration}\n'
 

--- a/batchflow/tests/notebooks/torch_test.ipynb
+++ b/batchflow/tests/notebooks/torch_test.ipynb
@@ -74,7 +74,8 @@
     "ExecuteTime": {
      "end_time": "2020-02-10T14:48:40.438798Z",
      "start_time": "2020-02-10T14:48:40.394276Z"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -84,19 +85,27 @@
     "\n",
     "def get_classification_config(model_class, config):\n",
     "    default_config = {\n",
-    "        'inputs/images/shape': IMAGE_SHAPE, # can be commented\n",
-    "        'inputs/labels/classes': 10,\n",
-    "        'initial_block/inputs': 'images',   # can be commented\n",
+    "        # Shapes info. Can be commented\n",
+    "        'inputs_shapes': IMAGE_SHAPE,\n",
+    "        'classes': 10,\n",
+    "\n",
     "        'loss': 'ce',\n",
-    "        'microbatch': MICROBATCH,\n",
+    "        'microbatch_size': MICROBATCH,\n",
     "        'device': DEVICE,\n",
     "    }\n",
     "\n",
+    "    if 'inputs_shapes' in config:\n",
+    "        inputs = [B.images for item in config['inputs_shapes']]\n",
+    "    else:\n",
+    "        inputs = B.images\n",
+    "    \n",
+    "    \n",
     "    pipeline_config = {\n",
     "        'model': model_class,\n",
     "        'model_config': {**default_config, **config},\n",
-    "        'feed_dict': {'images': B('images'),\n",
-    "                      'targets': B('labels')},\n",
+    "        'inputs': inputs,\n",
+    "        'targets': B.labels,\n",
+    "\n",
     "        'gather': {'metrics_class' : 'classification',\n",
     "                   'fmt' : 'logits',\n",
     "                   'axis' : 1,\n",
@@ -107,19 +116,26 @@
     "\n",
     "def get_segmentation_config(model_class, config):\n",
     "    default_config = {\n",
-    "        'inputs/images/shape': IMAGE_SHAPE, # can be commented\n",
-    "        'inputs/masks/shape': IMAGE_SHAPE,  # can be commented\n",
-    "        'initial_block/inputs': 'images',   # can be commented\n",
+    "        # Shapes info. Can be commented\n",
+    "        'inputs_shapes': IMAGE_SHAPE,\n",
+    "        'targets_shapes': IMAGE_SHAPE,\n",
+    "\n",
     "        'loss': 'mse',\n",
     "        'microbatch': MICROBATCH,\n",
     "        'device': DEVICE,\n",
     "    }\n",
     "    \n",
+    "    if 'inputs_shapes' in config:\n",
+    "        inputs = [B.images for item in config['inputs_shapes']]\n",
+    "    else:\n",
+    "        inputs = B.images\n",
+    "    \n",
     "    pipeline_config = {\n",
     "        'model': model_class,\n",
     "        'model_config': {**default_config, **config},\n",
-    "        'feed_dict': {'images': B('images'),\n",
-    "                      'targets': B('images')},\n",
+    "        'inputs': inputs,\n",
+    "        'targets': B.images,\n",
+    "\n",
     "        'gather': {'metrics_class' : 'segmentation',\n",
     "                   'fmt' : 'proba',\n",
     "                   'axis' : None,\n",
@@ -136,24 +152,22 @@
     "ExecuteTime": {
      "end_time": "2020-02-10T14:48:40.485464Z",
      "start_time": "2020-02-10T14:48:40.440559Z"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "def get_pipeline(pipeline_config):\n",
     "    \"\"\" Pipeline config must contain 'model', 'model_config', 'feed_dict' keys. \"\"\"\n",
-    "    vals = pipeline_config['feed_dict'].values()\n",
-    "\n",
     "    pipeline = (Pipeline(config=pipeline_config)\n",
     "                .init_variable('loss_history', [])\n",
     "                .to_array(channels='first', dtype='float32')\n",
     "                .multiply(multiplier=1/255., preserve_type=False)\n",
     "                .init_model(name='MODEL', model_class=C('model'), config=C('model_config'))\n",
     "                .train_model('MODEL',\n",
-    "#                              *vals,\n",
-    "#                              feed_dict=C('feed_dict'),\n",
-    "                             **pipeline_config['feed_dict'],\n",
-    "                             fetches='loss',\n",
+    "                             inputs=pipeline_config['inputs'],\n",
+    "                             targets=pipeline_config['targets'],\n",
+    "                             outputs='loss',\n",
     "                             save_to=V('loss_history', mode='a'))\n",
     "                )\n",
     "    return pipeline"
@@ -166,7 +180,8 @@
     "ExecuteTime": {
      "end_time": "2020-02-10T14:48:40.517771Z",
      "start_time": "2020-02-10T14:48:40.486919Z"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -192,7 +207,8 @@
     "ExecuteTime": {
      "end_time": "2020-02-10T14:48:40.556069Z",
      "start_time": "2020-02-10T14:48:40.520751Z"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -221,7 +237,8 @@
     "ExecuteTime": {
      "end_time": "2020-02-10T14:48:40.598310Z",
      "start_time": "2020-02-10T14:48:40.557588Z"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -233,11 +250,10 @@
     "                    .init_variable('metrics', default=[]) \n",
     "                    .to_array(channels='first', dtype='float32')\n",
     "                    .multiply(multiplier=1/255., preserve_type=False)\n",
-    "                    .update(V('targets', mode='a'), pipeline.config['feed_dict/targets'])\n",
+    "                    .update(V('targets', mode='a'), pipeline.config['targets'])\n",
     "                    .predict_model('MODEL',\n",
-    "#                                    targets=B.images,\n",
-    "                                   feed_dict=pipeline.config['feed_dict'],\n",
-    "                                   fetches='predictions',\n",
+    "                                   inputs=pipeline.config['inputs'],\n",
+    "                                   outputs='predictions',\n",
     "                                   save_to=V('predictions', mode='a'))\n",
     "                    .gather_metrics(**pipeline.config['gather'], predictions=V.predictions[-1],\n",
     "                                    save_to=V('metrics', mode='a'))\n",
@@ -269,7 +285,8 @@
     "ExecuteTime": {
      "end_time": "2020-02-10T14:48:49.391057Z",
      "start_time": "2020-02-10T14:48:40.601257Z"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -297,7 +314,8 @@
     "ExecuteTime": {
      "end_time": "2020-02-14T12:36:22.116738Z",
      "start_time": "2020-02-14T12:36:21.721466Z"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -316,7 +334,8 @@
     "ExecuteTime": {
      "end_time": "2020-02-10T14:48:50.090131Z",
      "start_time": "2020-02-10T14:48:49.763142Z"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -339,12 +358,13 @@
     "ExecuteTime": {
      "end_time": "2020-02-10T14:48:50.496333Z",
      "start_time": "2020-02-10T14:48:50.091585Z"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "config = {\n",
-    "    'initial_block/inputs': ['images', 'images'],\n",
+    "    'inputs_shapes': (IMAGE_SHAPE, IMAGE_SHAPE),\n",
     "    # note that we can't directly assign this module to `initial_block`\n",
     "    'initial_block/module': Combine(op='+'),\n",
     "    'body/encoder': {'num_stages': 5},\n",
@@ -361,7 +381,8 @@
     "ExecuteTime": {
      "end_time": "2020-02-14T12:41:40.763896Z",
      "start_time": "2020-02-14T12:41:37.322622Z"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -383,7 +404,8 @@
     "ExecuteTime": {
      "end_time": "2020-02-14T12:36:33.046337Z",
      "start_time": "2020-02-14T12:36:26.373349Z"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -399,7 +421,8 @@
     "ExecuteTime": {
      "end_time": "2020-02-10T14:49:03.632479Z",
      "start_time": "2020-02-10T14:49:00.150428Z"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -413,7 +436,8 @@
     "ExecuteTime": {
      "end_time": "2020-02-10T14:49:07.166937Z",
      "start_time": "2020-02-10T14:49:03.721908Z"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -433,7 +457,8 @@
     "ExecuteTime": {
      "end_time": "2020-02-10T14:49:13.071000Z",
      "start_time": "2020-02-10T14:49:07.169608Z"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -468,7 +493,8 @@
     "ExecuteTime": {
      "end_time": "2020-02-10T14:49:13.696338Z",
      "start_time": "2020-02-10T14:49:13.081798Z"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -488,7 +514,8 @@
     "ExecuteTime": {
      "end_time": "2020-02-10T14:49:44.607432Z",
      "start_time": "2020-02-10T14:49:43.604775Z"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -512,7 +539,8 @@
     "ExecuteTime": {
      "end_time": "2020-02-10T14:49:46.448465Z",
      "start_time": "2020-02-10T14:49:45.798839Z"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -532,7 +560,8 @@
     "ExecuteTime": {
      "end_time": "2020-02-10T14:49:48.472236Z",
      "start_time": "2020-02-10T14:49:47.070986Z"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -555,7 +584,8 @@
     "ExecuteTime": {
      "end_time": "2020-02-10T14:49:52.971834Z",
      "start_time": "2020-02-10T14:49:49.071501Z"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -579,7 +609,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "config = {\n",
@@ -592,7 +624,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "config = {\n",
@@ -605,7 +639,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "config = {\n",
@@ -619,7 +655,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "config = {\n",
@@ -637,7 +675,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "test(ppl)"
@@ -646,17 +686,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "plt.plot(ppl.m('MODEL').loss_list)\n",
-    "plt.grid()"
+    "ppl.m('MODEL').show_loss()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "ppl.m('MODEL').show_lr()"
@@ -665,7 +708,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "monitor.visualize()"
@@ -674,7 +719,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true,
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "ppl.m('MODEL').short_repr()"
@@ -687,17 +735,20 @@
     "ExecuteTime": {
      "end_time": "2020-02-14T12:41:11.908921Z",
      "start_time": "2020-02-14T12:41:11.875720Z"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
-    "ppl.m('MODEL').information(misc=True)"
+    "ppl.m('MODEL').information()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "config = {\n",
@@ -710,11 +761,33 @@
     "\n",
     "ppl = run('classification', ResNet34, config, 'resnet34', batch_size=64, n_iters=200, prefetch=5)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "ppl.m('MODEL').show_loss()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "ppl.m('MODEL').show_lr()"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -728,7 +801,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.8.10"
   },
   "varInspector": {
    "cols": {

--- a/docs/intro/torch_models.rst
+++ b/docs/intro/torch_models.rst
@@ -287,7 +287,7 @@ Here we split network configuration and network definition into separate methods
 
         @classmethod
         def body(cls, **kwargs):
-            kwargs = cls.get_defaults('body', kwargs)
+            kwargs = cls.get_block_defaults('body', kwargs)
             x = ConvBlock(**kwargs)
             return x
 

--- a/pylintrc
+++ b/pylintrc
@@ -20,7 +20,7 @@ ignored-modules=numpy,cv2
 
 [MESSAGE CONTROL]
 no-docstring-rgx=^(_|forward)
-disable=no-member, no-value-for-parameter, no-self-use, too-many-branches, unsubscriptable-object, redefined-variable-type, too-many-star-expressions, duplicate-code, not-context-manager, too-many-lines, global-statement, locally-disabled, wrong-import-position, invalid-sequence-index, redundant-keyword-arg, bad-super-call, no-self-argument, redefined-builtin, arguments-differ, len-as-condition, keyword-arg-before-vararg, assignment-from-none, useless-return, useless-import-alias, unnecessary-pass, cyclic-import, assignment-from-no-return, comparison-with-callable, unnecessary-lambda, import-outside-toplevel, import-error, abstract-method
+disable=no-member, no-value-for-parameter, no-self-use, too-many-branches, unsubscriptable-object, redefined-variable-type, too-many-star-expressions, duplicate-code, not-context-manager, too-many-lines, global-statement, locally-disabled, wrong-import-position, invalid-sequence-index, redundant-keyword-arg, bad-super-call, no-self-argument, redefined-builtin, arguments-differ, len-as-condition, keyword-arg-before-vararg, assignment-from-none, useless-return, useless-import-alias, unnecessary-pass, cyclic-import, assignment-from-no-return, comparison-with-callable, unnecessary-lambda, import-outside-toplevel, import-error, abstract-method, too-many-ancestors
 
 [BASIC]
 class-rgx=[A-Z_][a-zA-Z0-9_]+$


### PR DESCRIPTION
This PR proposes to:

## Refactor the inputs/targets logic of `TorchModel`. 
Previously, we allowed to use `*args`, `**kwargs` and even `feed_dict` in both `train` and `predict` methods, as well as in the visualization tools like `get_gradcam`. This was ugly in code (and required ~50+ lines of parsing), and was prone to errors, especially in the multi-input or multi-output settings. It is very unintuitive to use as you can essentially pass anything to a model and hope it would arrange elements in correct order. Moreover, as `targets` have no defined argument, they are parsed by using hardcoded names, which is very confusing when works incorrectly.

In this PR, a different logic is implemented. All of the above methods now accept `inputs` and `targets` arguments, that are passed directly to the model or loss computation function.
Inside the code, they are always treated like sequences of `np.narrays`, which makes it easy to, for example, split both inputs and targets into microbatches, compute their shapes, and assert some additional properties for better user experience.
The only thing we (possibly) do with those arguments is, if there is only one element, we pass it to model / loss directly, so you don't need to worry about single-element sequences inside your `forward` pass.

## Improve the `fetches` behavior
The `fetches` parameter is renamed to `outputs`.
As previously, one can use pre-defined aliases to get parts of the network, i.e. `predictions` and `loss`. The list of aliases is extended by:
- `predictions_{i}` to get the i-th tensor of model output
- `predictions_{i}_{j}` to get the j-th operation, defined in the `outputs` config section, applied to the i-th tensor. For example, if the `config['outputs'] = {'first_tensor': ['sigmoid', 'softmax', custom_callable]}`, then the `predictions_0_1` gets the result of `softmax` operation, applied to the first tensor

Moreover, now we accept layer identifiers to get the intermediate activations from a neural network. The layer identifier is a string that defines how to get a layer in the model, and uses the same semantics, as the usual `getattr`/`getitem` way.

For example, if you can access a particular layer by 
```python
batchflow_model.model.body.encoder["block-1"][0].layer
```
then you can pass the 
```python
'model.body.encoder["block-1"][0].layer'
```
string as one of the `outputs` to retrieve the activations from exactly this part of the NN. Note that all of the layer identifiers start with `'model.'` prefix.

This logic is currently used only in `predict` method, not in `train`. Comment, if you see the use case for it to be in `train` as well.

## Re-arrange parts of the code to be more cohesive
The `TorchModel` code serves two main purposes: to create a `PyTorch model` instance and to provide infrastructure for its training. Now there is a clearer separation between the two.

Also, the `build` stage of the `TorchModel` instance is now explicitly split into `update instance attributes from passed config` and `update config with parsed attributes` stages. 

## Improve textual and graphical visualizations
- fixed a lot of newlines in the `.information` visualization
- added a loss plot
- more info is saved to `last_iteration_info` dictionary during the `train` pass
- a lot of methods are now public, so they have documentation and explanation of inner workings. Also, methods are reoranged to better correspond to logic of their usage

# Proposals
Additionally, I think that it would be beneficial to:

- Remove the `BaseModel` or at least move all the loading logic from it to the `TorchModel` itself. 
Now, as there is only one framework we support (#629), it would be easier to comprehend if all the code regarding `TorchModel` would be in the same place.

- Rename `.config` and `.full_config` attributes into `.external_config` and `.config` respectively. This would make it easier to understand the meaning of all of these configs.

- Make a separate `model_config`, which is subset of the main configuration by `order` and its elements keys.
As of now, there is no clear explanation to why we need to first parse instance attributes from config and then update config with some of the instance attributes. In reality, we need to update only the `model_config`, which makes sense, as model creation parameters can be unknown before we get additional information about the runtime (for example, we can infer shapes from passed batch data, which are unknown at instance initialization from config).


Update 15/12/2021: added `microbatch` to `predict`, as well as the `layer id` parsing logic to train.