### PR TITLE
Fix warning from opensets; Fix split_to_patches

### DIFF
--- a/batchflow/opensets/base.py
+++ b/batchflow/opensets/base.py
@@ -1,6 +1,5 @@
 """ Contains the base class for open datasets """
 import numpy as np
-import PIL
 
 from .. import Dataset, DatasetIndex
 from .. import ImagesBatch
@@ -43,6 +42,7 @@ class Openset(Dataset):
         return index, train_index, test_index
 
     def create_array(self, images):
+        """ Create numpy array of objects. """
         array = np.empty(len(images), dtype=object)
         for i, image in enumerate(images):
             array[i] = image

--- a/batchflow/opensets/base.py
+++ b/batchflow/opensets/base.py
@@ -1,4 +1,7 @@
 """ Contains the base class for open datasets """
+import numpy as np
+import PIL
+
 from .. import Dataset, DatasetIndex
 from .. import ImagesBatch
 
@@ -38,6 +41,12 @@ class Openset(Dataset):
         train_index = DatasetIndex(list(range(train_len)))
         test_index = DatasetIndex(list(range(train_len, total_len)))
         return index, train_index, test_index
+
+    def create_array(self, images):
+        array = np.empty(len(images), dtype=object)
+        for i, image in enumerate(images):
+            array[i] = image
+        return array
 
 
 class ImagesOpenset(Openset):

--- a/batchflow/opensets/cifar.py
+++ b/batchflow/opensets/cifar.py
@@ -41,7 +41,7 @@ class BaseCIFAR(ImagesOpenset):
 
         def _gather_extracted(all_res):
             images = np.concatenate([res[b'data'] for res in all_res]).reshape((-1, 3, 32, 32)).transpose((0, 2, 3, 1))
-            images = np.array([PIL.Image.fromarray(image) for image in images], dtype=object)
+            images = self.create_array([PIL.Image.fromarray(image) for image in images])
             labels = np.concatenate([res[self.LABELS_KEY] for res in all_res])
             return images, labels
 

--- a/batchflow/opensets/imagenette.py
+++ b/batchflow/opensets/imagenette.py
@@ -69,7 +69,7 @@ class Imagenette(ImagesOpenset):
             return member.isfile() and _extract(archive, member).mode == 'RGB'
 
         def _gather_extracted(archive, files):
-            images = np.array([_extract(archive, file) for file in files], dtype=object)
+            images = self.create_array([_extract(archive, file) for file in files])
             labels = np.array([_image_class(file.name) for file in files])
             _, labels_encoded = np.unique(labels, return_inverse=True)
             return images, labels_encoded

--- a/batchflow/opensets/mnist.py
+++ b/batchflow/opensets/mnist.py
@@ -118,7 +118,7 @@ class MNIST(ImagesOpenset):
             buf = bytestream.read(rows * cols * num_images)
             data = np.frombuffer(buf, dtype=np.uint8)
             data = data.reshape(num_images, rows, cols)
-            return np.array([PIL.Image.fromarray(image) for image in data], dtype=object)
+            return self.create_array([PIL.Image.fromarray(image) for image in data])
 
     def _extract_labels(self, f):
         """Extract the labels into a 1D uint8 numpy array [index].

--- a/batchflow/opensets/pascal.py
+++ b/batchflow/opensets/pascal.py
@@ -104,10 +104,10 @@ class PascalSegmentation(BasePascal):
             train_ids = self._extract_ids(archive, 'train')
             test_ids = self._extract_ids(archive, 'val')
 
-            images = np.array([self._extract_image(archive, self._image_path(name)) \
-                               for name in  [*train_ids, *test_ids]], dtype=object)
-            masks = np.array([self._extract_image(archive, self._mask_path(name)) \
-                              for name in [*train_ids, *test_ids]], dtype=object)
+            images = self.create_array([self._extract_image(archive, self._image_path(name)) \
+                                        for name in  [*train_ids, *test_ids]])
+            masks = self.create_array([self._extract_image(archive, self._mask_path(name)) \
+                                       for name in [*train_ids, *test_ids]])
             preloaded = images, masks
 
             train_len, test_len = len(train_ids), len(test_ids)
@@ -160,8 +160,8 @@ class PascalClassification(BasePascal):
             train_ids = self._extract_ids(archive, 'train')
             test_ids = self._extract_ids(archive, 'val')
 
-            images = np.array([self._extract_image(archive, self._image_path(name))
-                               for name in [*train_ids, *test_ids]], dtype=object)
+            images = self.create_array([self._extract_image(archive, self._image_path(name))
+                                        for name in [*train_ids, *test_ids]])
 
             targets = np.array([d[self._name(name)] for name in [*train_ids, *test_ids]])
             labels = self._process_targets(targets)


### PR DESCRIPTION
- Fix `split_to_patches`
- Fix warnings like 
```
FutureWarning: The input object of type 'JpegImageFile' is an array-like implementing one of the corresponding protocols 
(`__array__`, `__array_interface__` or `__array_struct__`); but not a sequence (or 0-D). In the future, this object will be coerced 
as if it was first converted using `np.array(obj)`. To retain the old behaviour, you have to either modify the type 'JpegImageFile', 
or assign to an empty array created with `np.empty(correct_shape, dtype=object)`.
images = np.array([_extract(archive, file) for file in files], dtype=object)
```