### PR TITLE
Fix chained callables

### DIFF
--- a/batchflow/named_expr.py
+++ b/batchflow/named_expr.py
@@ -339,6 +339,7 @@ class AlgebraicNamedExpression(NamedExpression):
     def get(self, **kwargs):
         """ Return a value of an algebraic expression """
         if self.op == '#call':
+            kwargs.pop('_call', None)
             a = eval_expr(self.a, _call=False, **kwargs)
         else:
             a = eval_expr(self.a, **kwargs)

--- a/batchflow/tests/named_expr_test.py
+++ b/batchflow/tests/named_expr_test.py
@@ -270,3 +270,12 @@ def test_l(batch_size):
         assert np.allclose(batch.object[i].cattr, batch.object[i].other.cattr)
         assert batch.object[i].func_args == (1, 0)
         assert batch.object[i].func_kwargs == {'a': 5, 'b': 0}
+
+def test_callable():
+    """Test chained callables."""
+    batch = (Dataset(4).p
+        .update(B('object'), np.arange(4))
+        .update(B('object'), B('object').repeat(2).sum())
+    ).next_batch(4)
+
+    assert batch.object == 12


### PR DESCRIPTION
Fix for expressions like `B('name').attr1().attr2()`