### PR TITLE
Use `plot` in tutorial notebook instead of outdated `plot_images`

### DIFF
--- a/batchflow/batch_image.py
+++ b/batchflow/batch_image.py
@@ -413,7 +413,7 @@ class ImagesBatch(BaseImagesBatch):
         return rescaled_image
 
     @apply_parallel
-    def crop(self, image, origin, shape, crop_boundaries=False, **kwargs):
+    def crop(self, image, origin, shape, crop_boundaries=False, src=None, dst=None):
         """ Crop an image.
 
         Extract image data from the window of the size given by `shape` and placed at `origin`.
@@ -568,7 +568,7 @@ class ImagesBatch(BaseImagesBatch):
         return image.transform(*args, size=size, **kwargs)
 
     @apply_parallel
-    def resize(self, image, size, *args, **kwargs):
+    def resize(self, image, size, src=None, dst=None, *args, **kwargs):
         """ Calls ``image.resize(*args, **kwargs)``.
 
         For more details see `<https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.resize>_`.
@@ -594,13 +594,10 @@ class ImagesBatch(BaseImagesBatch):
         else:
             new_size = size
 
-        _ = kwargs.pop('src')
-        _ = kwargs.pop('dst')
-
         return image.resize(new_size, *args, **kwargs)
 
     @apply_parallel
-    def shift(self, image, offset, mode='const', **kwargs):
+    def shift(self, image, offset, mode='const', src=None, dst=None):
         """ Shifts an image.
 
         Parameters
@@ -672,7 +669,7 @@ class ImagesBatch(BaseImagesBatch):
         return image.rotate(*args, **kwargs)
 
     @apply_parallel
-    def flip(self, image, mode='lr', **kwargs):
+    def flip(self, image, mode='lr', src=None, dst=None):
         """ Flips image.
 
         Parameters
@@ -828,7 +825,7 @@ class ImagesBatch(BaseImagesBatch):
         return image
 
     @apply_parallel
-    def multiply(self, image, multiplier=1., clip=False, preserve_type=False, **kwargs):
+    def multiply(self, image, multiplier=1., clip=False, preserve_type=False, src=None, dst=None):
         """ Multiply each pixel by the given multiplier.
 
         Parameters

--- a/batchflow/batch_image.py
+++ b/batchflow/batch_image.py
@@ -439,6 +439,8 @@ class ImagesBatch(BaseImagesBatch):
         element, as origin will be sampled independently for each `src` element.
         To randomly sample same origin for a number of components, use `R` named expression for `origin` argument.
         """
+        _ = src, dst
+
         origin = self._calc_origin(shape, origin, image.size)
         right_bottom = origin + shape
 
@@ -585,6 +587,8 @@ class ImagesBatch(BaseImagesBatch):
         p : float
             Probability of applying the transform. Default is 1.
         """
+        _ = src, dst
+
         if size[0] is None and size[1] is None:
             raise ValueError('At least one component of the parameter "size" must be a number.')
         if size[0] is None:
@@ -612,6 +616,8 @@ class ImagesBatch(BaseImagesBatch):
         p : float
             Probability of applying the transform. Default is 1.
         """
+        _ = src, dst
+
         if mode == 'const':
             image = image.transform(size=image.size,
                                     method=PIL.Image.AFFINE,
@@ -685,6 +691,8 @@ class ImagesBatch(BaseImagesBatch):
         p : float
             Probability of applying the transform. Default is 1.
         """
+        _ = src, dst
+
         if mode == 'lr':
             return PIL.ImageOps.mirror(image)
         return PIL.ImageOps.flip(image)
@@ -843,6 +851,8 @@ class ImagesBatch(BaseImagesBatch):
         p : float
             Probability of applying the transform. Default is 1.
         """
+        _ = src, dst
+
         multiplier = np.float32(multiplier)
         if isinstance(image, PIL.Image.Image):
             if preserve_type is False:

--- a/batchflow/models/metrics/classify.py
+++ b/batchflow/models/metrics/classify.py
@@ -181,8 +181,14 @@ class ClassificationMetrics(Metrics):
             'title': 'Normalized confusion matrix' if normalize else 'Confusion matrix',
             'xlabel': 'Actual class',
             'xtick_locations': np.arange(confusion_matrix.shape[0]),
+            'xtick_labels': classes,
+            'xtick_rotation': 90,
+            'xtick_ha': 'center',
             'ylabel': 'Predicted class',
             'ytick_locations': np.arange(confusion_matrix.shape[1]),
+            'ytick_labels': classes,
+            'ytick_rotation': 0,
+            'ytick_va': 'center',
             **kwargs
         }
 

--- a/batchflow/plotter/plot.py
+++ b/batchflow/plotter/plot.py
@@ -618,7 +618,7 @@ class Subplot:
         grid = self.config.get('grid', None)
         grid_config = self.config.filter(prefix='grid_')
 
-        if grid in [None, False]:
+        if grid in (None, False):
             self.ax.grid()
 
         if grid in ('minor', 'both'):

--- a/batchflow/plotter/plot.py
+++ b/batchflow/plotter/plot.py
@@ -618,6 +618,9 @@ class Subplot:
         grid = self.config.get('grid', None)
         grid_config = self.config.filter(prefix='grid_')
 
+        if grid in [None, False]:
+            self.ax.grid()
+
         if grid in ('minor', 'both'):
             minor_grid_config = self.config.filter(prefix='minor_grid_')
             minor_grid_config = minor_grid_config.update(grid_config, skip_duplicates=True)

--- a/batchflow/plotter/plot.py
+++ b/batchflow/plotter/plot.py
@@ -204,7 +204,6 @@ class Layer:
 
         image_keys = ['alpha', 'vmin', 'vmax', 'extent']
         image_config = self.config.filter(keys=image_keys, prefix='image_')
-
         image = self.ax.imshow(data, cmap=cmap, **image_config)
 
         return [image]
@@ -653,7 +652,8 @@ class Subplot:
 
         return colorbar
 
-    def add_legend(self, mode='image', label=None, color='none', alpha=1, size=15, **kwargs):
+    def add_legend(self, mode='image', label=None, color='none', alpha=1,
+                   size=15, family='sans-serif', properties=None, **kwargs):
         """ Add patches to subplot legend.
 
         Parameters
@@ -671,10 +671,18 @@ class Subplot:
         alpha : number or list of numbers from 0 to 1
             Legend handles opacity.
         size : int
-            Legend size.
+            Legend text font size.
+        family : str
+            Legent text font family.
+        properties : dict
+            Legend font parameters, must be valid for `matplotlib.font_manager.FontProperties`.
         kwargs : misc
             For `matplotlib.legend`.
         """
+        if properties is None:
+            properties = {}
+        properties = {'size': size, 'family': family, **properties}
+
         # get legend that already exists
         legend = self.ax.get_legend()
         old_handles = getattr(legend, 'legendHandles', [])
@@ -689,6 +697,7 @@ class Subplot:
         for label_item, label_color, label_alpha in zip(labels, colors, alphas):
             if label_item is None:
                 continue
+
             if isinstance(label_item, str):
                 if mode in ('image', 'histogram'):
                     if is_color_like(label_color):
@@ -705,7 +714,7 @@ class Subplot:
         if len(new_handles) > 0:
             # extend existing handles and labels with new ones
             handles = old_handles + new_handles
-            legend = self.ax.legend(prop={'size': size}, handles=handles,  handler_map=handler_map, **kwargs)
+            legend = self.ax.legend(prop=properties, handles=handles,  handler_map=handler_map, **kwargs)
 
         return legend
 


### PR DESCRIPTION
Note, that there is a bug that show itself, when calling `train_model` action in corresponding pipeline. Since fixing this goes beyond the limits of current PR, the updated plot contents correspond to model predictions, that was not trained at all. Just re-run the notebook after fixing mentioned bug, and all the plots should come back together and relevant.