### PR TITLE
Fix some bugs

### DIFF
--- a/batchflow/batch.py
+++ b/batchflow/batch.py
@@ -90,7 +90,7 @@ class Batch(metaclass=MethodsTransformingMeta):
 
     def __init__(self, index, dataset=None, pipeline=None, preloaded=None, copy=False, *args, **kwargs):
         _ = args
-        if  self.components is not None and not isinstance(self.components, tuple):
+        if self.components is not None and not isinstance(self.components, tuple):
             raise TypeError("components should be a tuple of strings with components names")
         self.index = index
         self._preloaded_lock = threading.Lock()

--- a/batchflow/batch_image.py
+++ b/batchflow/batch_image.py
@@ -49,8 +49,9 @@ class BaseImagesBatch(Batch):
         path : str
             Full path to an element.
         """
-
-        if isinstance(src, FilesIndex):
+        if src is None:
+            path = str(ix)
+        elif isinstance(src, FilesIndex):
             path = src.get_fullpath(ix)
         elif isinstance(self.index, FilesIndex):
             path = self.index.get_fullpath(ix)


### PR DESCRIPTION
1. Allow `BaseImageBatch` call with `src=None` (assuming that the `ix` itself is already a full path to image).
2. ~~Undo `src` and `dst` being passed by `BaseImagesBatch.apply_parallel` to batch actions (recent bug, introduced in 4a106c7228542a6bc5d69a66df8d86fab7d3b058).~~