### PR TITLE
Change config

### DIFF
--- a/batchflow/config.py
+++ b/batchflow/config.py
@@ -212,6 +212,7 @@ class Config(dict):
             A key in the dictionary. '/' is used to get value from nested dict.
         default : misc
             Default value if key doesn't exist in config.
+            If key has several variables, `default` can be a list with defaults for each variable.
 
         Returns
         -------


### PR DESCRIPTION
A new version of config supports any hashable object as key (like a simple dict):
![image](https://github.com/analysiscenter/batchflow/assets/106237959/704e4692-9cfa-4c8f-88dc-39e97452b1f5)
However, due to the fact that tests were written for the old version of config which supports only ```str``` as a key, some of them are failed 