### PR TITLE
Add weighted sampler

### DIFF
--- a/batchflow/sampler.py
+++ b/batchflow/sampler.py
@@ -151,8 +151,7 @@ class Sampler():
             result of the multiplication.
         """
         if isinstance(other, (float, int)):
-            self.weight *= other
-            return self
+            return WeightedSampler(self, self.weight * other)
 
         return AndSampler(self, other)
 
@@ -340,6 +339,19 @@ class TruncateSampler(Sampler):
             ctr += 1
 
         return np.concatenate(samples)[:size]
+
+class WeightedSampler(Sampler):
+    """ Class for implementing `&` (weighting) operation on a number and a `Sampler` instance.
+    """
+    def __init__(self, base, weight):
+        self.bases = [base]
+        self.weight = weight
+
+    def sample(self, size):
+        """ Sampling procedure of a product of the number and the sampler instance. Check out the docstring of
+        `Sampler.sample` for more info.
+        """
+        return self.bases[0].sample(size)
 
 
 class BaseOperationSampler(Sampler):

--- a/batchflow/sampler.py
+++ b/batchflow/sampler.py
@@ -343,7 +343,8 @@ class TruncateSampler(Sampler):
 class WeightedSampler(Sampler):
     """ Class for implementing `&` (weighting) operation on a number and a `Sampler` instance.
     """
-    def __init__(self, base, weight):
+    def __init__(self, base, weight, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.bases = [base]
         self.weight = weight
 


### PR DESCRIPTION
This PR fixes the non-obvious bug when using `OrSampler`: the multiplication changes the sampler weight inplace which in some cases can be crucial.

**e.g.** `other_sampler = (1 & sampler_1)| (0 & sampler_2)` will change `sampler_1` and `sampler_2` weights