### PR TITLE
Update for matplotlib

### DIFF
--- a/batchflow/plotter/cmaps.py
+++ b/batchflow/plotter/cmaps.py
@@ -1,11 +1,11 @@
 """ Custom colormaps. """
-from matplotlib.pyplot import register_cmap
+from matplotlib import colormaps
 from .utils import extend_cmap
 
 
 
 BATCHFLOW_CMAP = extend_cmap('magma', 'white')
 try:
-    register_cmap('batchflow', BATCHFLOW_CMAP)
+    colormaps.register(cmap=BATCHFLOW_CMAP, name='batchflow')
 except ValueError:
     pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ tqdm = "^4.19"
 
 # [tool.poetry.group.image.dependencies]
 pillow = { version = ">=9.4,<11.0", optional = true }
-matplotlib = { version = "^3.0", optional = true }
+matplotlib = { version = "^3.7", optional = true }
 
 # [tool.poetry.group.research.dependencies]
 multiprocess = { version = "^0.70", optional = true }


### PR DESCRIPTION
Necessary for `matplotlib>=3.9.0` but also works for older versions (e.g. `3.7.5`)
Closes #746 