### PR TITLE
Changed the way the optimizer is saved: only its state_dict is pickled

### DIFF
--- a/batchflow/models/torch/base.py
+++ b/batchflow/models/torch/base.py
@@ -1747,8 +1747,10 @@ class TorchModel(BaseModel, ExtractionMixin, OptimalBatchSizeMixin, Visualizatio
                        path, pickle_module=pickle_module, **kwargs)
 
         else:
-            torch.save({item: getattr(self, item) for item in self.PRESERVE},
-                       path, pickle_module=pickle_module, **kwargs)
+            attributes = {item: getattr(self, item) for item in self.PRESERVE if item != "optimizer"}
+            optimizer = getattr(self, "optimizer")
+            attributes["optimizer"] = optimizer.state_dict()
+            torch.save(attributes, path, pickle_module=pickle_module, **kwargs)
 
     def load(self, file, make_infrastructure=False, mode='eval', pickle_module=dill, **kwargs):
         """ Load a torch model from a file.


### PR DESCRIPTION
Optimizer cannot be pickled in later PyTorch version directly - their `optimizer.state_dict()` object must be saved instead. This little change ensures that `optimizer` attribute saves only `state_dict`