### PR TITLE
Fix save model

### DIFF
--- a/batchflow/models/torch/base.py
+++ b/batchflow/models/torch/base.py
@@ -1726,7 +1726,9 @@ class TorchModel(BaseModel, ExtractionMixin, OptimalBatchSizeMixin, Visualizatio
             torch.onnx.export(self.model.eval(), inputs, path_onnx, opset_version=opset_version)
 
             # Save the rest of parameters
-            preserved = set(self.PRESERVE) - set(ignore_attributes) - set(['model', 'loss', 'optimizer', 'scaler', 'decay'])
+            ignore_attributes = set(ignore_attributes) + set(['model', 'loss', 'optimizer', 'scaler', 'decay'])
+            preserved = set(self.PRESERVE) - ignore_attributes
+
             preserved_dict = {item: getattr(self, item) for item in preserved}
             torch.save({'onnx': True, 'path_onnx': path_onnx, 'onnx_batch_size': batch_size, **preserved_dict},
                        path, pickle_module=pickle_module, **kwargs)
@@ -1748,7 +1750,8 @@ class TorchModel(BaseModel, ExtractionMixin, OptimalBatchSizeMixin, Visualizatio
             ov.save_model(model, output_model=path_openvino)
 
             # Save the rest of parameters
-            preserved = set(self.PRESERVE) - set(ignore_attributes) - set(['model', 'loss', 'optimizer', 'scaler', 'decay'])
+            ignore_attributes = set(ignore_attributes) + set(['model', 'loss', 'optimizer', 'scaler', 'decay'])
+            preserved = set(self.PRESERVE) - ignore_attributes
             preserved_dict = {item: getattr(self, item) for item in preserved}
             torch.save({'openvino': True, 'path_openvino': path_openvino, **preserved_dict},
                        path, pickle_module=pickle_module, **kwargs)

--- a/batchflow/models/torch/base.py
+++ b/batchflow/models/torch/base.py
@@ -1755,7 +1755,7 @@ class TorchModel(BaseModel, ExtractionMixin, OptimalBatchSizeMixin, Visualizatio
 
         else:
             preserved = set(self.PRESERVE) - set(ignore_attributes)
-            torch.save({item: getattr(self, item) for item in self.PRESERVE},
+            torch.save({item: getattr(self, item) for item in preserved},
                        path, pickle_module=pickle_module, **kwargs)
 
     def load(self, file, make_infrastructure=False, mode='eval', pickle_module=dill, **kwargs):

--- a/batchflow/models/torch/base.py
+++ b/batchflow/models/torch/base.py
@@ -1702,7 +1702,7 @@ class TorchModel(BaseModel, ExtractionMixin, OptimalBatchSizeMixin, Visualizatio
             Version of export standard to use.
         pickle_module : module
             Module to use for pickling.
-        ignore_attributes : str ot list, optional
+        ignore_attributes : str or iterable, optional
             List of attributes to ignore when pickling (e.g. 'optimizer')
         kwargs : dict
             Other keyword arguments, passed directly to :func:`torch.save`.


### PR DESCRIPTION
Add `ignore_attributes` to `save` method to avoid serialization issues for optimizer with the newest versions of pytorch and python