### PR TITLE
R0.9.2

### DIFF
--- a/batchflow/models/torch/base_mixins.py
+++ b/batchflow/models/torch/base_mixins.py
@@ -6,10 +6,7 @@ import numpy as np
 import torch
 
 from ...decorators import deprecated
-
-from ...utils_import import try_import
-plot = try_import(module='...plotter', package=__name__, attribute='plot',
-                  help='Try `pip install batchflow[image]`!')
+from ... import plot
 
 # Also imports `tensorboard`, if necessary
 


### PR DESCRIPTION
This pull request simplifies the import statements in the `batchflow/models/torch/base_mixins.py` file by removing the use of the `try_import` utility and directly importing the `plot` module.

* Simplified imports:
  * Replaced the dynamic import of `plot` using `try_import` with a direct import from the parent package. This change removes the need for the `try_import` utility and simplifies the code.